### PR TITLE
Add extension points to the BaseManifest repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,43 @@ you will have to define your ``TUTOR_PLUGINS_ROOT`` outside of your ``TUTOR_ROOT
 drydock will override your tutor env and erase your plugins.
 
 
+Extended builder
+~~~~~~~~~~~~~~~~
+Drydock also ships with an extended builder that adds the ability to use arbitrary
+templates as an extra overlay for the Kustomize app used by the base builder.
+To use it one must run drydock with the following reference:
+
+..  code:: yaml
+
+    ---
+    drydock:
+      builder_class:  drydock.manifest_builder.application.manifest_builder.ManifestBuilder
+      config_class: drydock.manifest_builder.infrastructure.tutor_config.TutorExtendedConfig
+      manifest_class: drydock.manifest_builder.infrastructure.tutor_based_manifests.ExtendedManifest
+      manifest_options:
+        output: "env"
+        extra_templates: extra_templates_root
+
+Where ``extra_templates_root`` points to the directory that holds your extra templates.
+In ``extra_templates_root`` you must include an directory named ``extra-extensions``.
+Inside ``extra-extensions`` you can write any template that you want but is meant to
+be used as a Kustomize overlay, therefore you will need at least a Kustomization.yml file.
+
+One use case is to use the extended builder to add helm chart definitions:
+
+..  code:: yaml
+
+    # extra_templates_root/extra-extensions/kustomization.yml
+    apiVersion: kustomize.config.k8s.io/v1beta1
+    kind: Kustomization
+
+    helmCharts:
+      - name: ingress-nginx
+        repo: https://kubernetes.github.io/ingress-nginx
+        namespace: ingress-nginx
+        version: 4.0.18
+        releaseName: ingress-nginxx
+
 Rationale
 ---------
 

--- a/drydock/manifest_builder/infrastructure/tutor_based_manifests.py
+++ b/drydock/manifest_builder/infrastructure/tutor_based_manifests.py
@@ -1,6 +1,7 @@
 """
 Collection of tutor based renderers for Kubernetes manifests.
 """
+import glob
 import os
 import shutil
 import tempfile
@@ -9,6 +10,7 @@ from os.path import join as path_join
 import pkg_resources
 from tutor import env as tutor_env
 from tutor import fmt, hooks
+from tutor.exceptions import TutorError
 
 from drydock.manifest_builder.domain.config import DrydockConfig
 from drydock.manifest_builder.domain.manifest_repository import ManifestRepository
@@ -20,6 +22,7 @@ class BaseManifests(ManifestRepository):
     Generates an environment based on Tutor with the relevant Kubernetes configuration
     to be tracked by version control.
     """
+
     TEMPLATE_ROOT = "kustomized/tutor13"
     TEMPLATE_TARGETS = [
         f"{TEMPLATE_ROOT}/base",
@@ -45,9 +48,7 @@ class BaseManifests(ManifestRepository):
         with hooks.Contexts.APP("drydock-base").enter():
             hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(pkg_resources.resource_filename("drydock", "templates"))
             hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
-                [
-                    (target, "drydock") for target in self.TEMPLATE_TARGETS
-                ],
+                [(target, "drydock") for target in self.TEMPLATE_TARGETS],
             )
         tutor_env.save(root, config.get_data())
         hooks.Filters.ENV_TEMPLATE_ROOTS.clear(context=hooks.Contexts.APP("drydock-base").name)
@@ -95,3 +96,95 @@ class BaseManifests(ManifestRepository):
             self.relocate_env(src, dst)
 
         fmt.echo_info(f"Drydock environment generated in {dst}")
+
+
+class ExtendedManifests(ManifestRepository):
+    """Include additional extension points"""
+
+    EXTENSIONS_DIRECTORY = "extra-extensions"
+
+    def __init__(self, options: dict) -> None:
+        """Initializes both an ExtendedManifest and a BaseManifests with `options`.
+
+        ExtendedManifest takes an aribitrary Tutor template root provided in the
+        options and renders it in the extra-extensions directory from BaseManifests
+
+        Parameters
+        ----------
+        options: dict
+            A superset of options from BaseManifests. In addition to the values expected
+            by BaseManifests, include the template root.
+        """
+        self.options = options
+        self.base_manifests = BaseManifests(options=options)
+
+    def save(self, config: DrydockConfig):
+        """Create a BaseManifests environment and add arbitrary templates.
+
+        Uses the BaseManifests environment and adds an extra directory `extra-extensions`
+        with arbitrary templates taken from extra_templates.
+
+        Parameters
+        ----------
+        config: DrydockConfig
+            A Tutor configuration extension.
+        """
+        tutor_root = config.get_root()
+        dst = path_join(tutor_root, self.options.get("output", "drydock-env"))
+
+        if not self.options.get("extra_templates"):
+            self.base_manifests.save(config)
+            return
+
+        hooks.Filters.ENV_PATCH("drydock-kustomization-resources").add_item(f"- {self.EXTENSIONS_DIRECTORY}")
+
+        self.base_manifests.save(config)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = path_join(tmpdir)
+            self.render(src, config)
+            self.relocate_env(src, dst)
+
+    def render(self, root: str, config: DrydockConfig) -> None:
+        """Register the arbitrary templates and render them.
+
+        This will add all the files and folders in EXTENSIONS_DIRECTORY
+        akin to "EXTENSIONS_DIRECTORY/*".
+        Parameters
+        ----------
+        root: str
+            path to use as a Tutor root
+        config: DrydockConfig
+            Tutor compatible configuration values.
+        """
+        template_root = self.options.get("extra_templates")
+        extensions_path = os.path.abspath(path_join(template_root, "extra-extensions"))
+
+        with hooks.Contexts.APP("drydock-extended").enter():
+            hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(template_root)
+            hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
+                [
+                    (f"{self.EXTENSIONS_DIRECTORY}/{os.path.basename(path)}", "drydock/")
+                    for path in glob.glob(path_join(extensions_path, "*"))
+                ]
+            )
+
+        tutor_env.save(root, config.get_data())
+        hooks.Filters.ENV_TEMPLATE_ROOTS.clear(context=hooks.Contexts.APP("drydock-extended").name)
+        hooks.Filters.ENV_TEMPLATE_TARGETS.clear(context=hooks.Contexts.APP("drydock-extended").name)
+        hooks.Filters.ENV_PATCHES.clear(context=hooks.Contexts.APP("drydock-extended").name)
+
+    def relocate_env(self, src: str, dst: str) -> None:
+        """Move the templates rendered in extra-extension to the drydock-env.
+
+        Parameters
+        ----------
+        src: str
+            root where the environment was generated
+        dst: str
+            destination of the final environment
+        """
+        base_dir = path_join(src, "env/drydock/", f"{self.EXTENSIONS_DIRECTORY}")
+        if not os.path.exists(base_dir):
+            raise TutorError("[DRYDOCK] Missing extra-extensions folder")
+        shutil.move(base_dir, dst)


### PR DESCRIPTION
## Description
This adds an additional manifest builder that creates an additional overlay on top of the ones generated by `BaseManifests`. `ExtendedManifests` will take the path defined in `extra_templates` in your drydock reference and render the templates living there on to your drydock-env.

## How to use

1. Modify you reference to include:

```yaml
  manifest_class: drydock.manifest_builder.infrastructure.tutor_based_manifests.ExtendedManifest
  manifest_options:
    extra_templates: extra_templates_root
```
2. Create the directories `extra_templates_root/extra-extensions` and add a `kustomization.yml` with you additional resources. Remember that this is a template and you have access to all the variables (e.g. `{{ K8S_NAMESPACE }}`).
3. Run `tutor drydock save -r reference.yml` to generate the new environment.