### PR TITLE
fix: use the correct init command for forum and add missing annotations

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/forum.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/forum.yml
@@ -22,7 +22,8 @@ spec:
           - -e
           - -c
           - 'bundle exec rake search:initialize
-            bundle exec rake search:rebuild_index'
+
+            bundle exec rake search:rebuild_indices'
         env:
           - name: SEARCH_SERVER
             value: "{{ ELASTICSEARCH_SCHEME }}://{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}"
@@ -34,10 +35,4 @@ spec:
             value: "{{ MONGODB_PORT }}"
           - name: MONGODB_DATABASE
             value: "{{ FORUM_MONGODB_DATABASE }}"
-          - name: MONGOHQ_URL
-            value: "mongodb://$(MONGODB_AUTH)$(MONGODB_HOST):$(MONGODB_PORT)/$(MONGODB_DATABASE)"
-          - name: SEARCH_SERVER_ES7
-            value: "$(SEARCH_SERVER)"
-          - name: MONGOID_AUTH_MECH
-            value: ":scram"
 {%- endif %}

--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/notes.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/notes.yml
@@ -33,6 +33,8 @@ metadata:
     app.kubernetes.io/component: job
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   ttlSecondsAfterFinished: 100
   template:
@@ -63,6 +65,8 @@ metadata:
     app.kubernetes.io/component: job
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   ttlSecondsAfterFinished: 100
   template:


### PR DESCRIPTION
## Description

There was a typo on the init command for the forum-job. Additionally some useful annotations for ArgoCD were missing from the notes jobs.