### PR TITLE
feat: removing MySQL jobs when MySQL running outside the cluster

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/cms.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/cms.yml
@@ -4,6 +4,8 @@ metadata:
   name: cms-job
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: cms
+    drydock.io/runner-service: cms
   annotations:
     argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/hook: Sync

--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/forum.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/forum.yml
@@ -5,6 +5,8 @@ metadata:
   name: forum-job
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: forum
+    drydock.io/runner-service: forum
   annotations:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/hook: Sync

--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/lms.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/lms.yml
@@ -4,6 +4,8 @@ metadata:
   name: lms-job
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: lms
+    drydock.io/runner-service: lms
   annotations:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/hook: Sync

--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/minio.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/minio.yml
@@ -5,6 +5,8 @@ metadata:
   name: minio-job
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: minio
+    drydock.io/runner-service: minio
   annotations:
     argocd.argoproj.io/sync-wave: "1"
     argocd.argoproj.io/hook: Sync

--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/mysql.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/mysql.yml
@@ -4,6 +4,8 @@ metadata:
   name: mysql-job
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: mysql
+    drydock.io/runner-service: mysql
   annotations:
     argocd.argoproj.io/sync-wave: "1"
     argocd.argoproj.io/hook: Sync

--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/notes.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/notes.yml
@@ -5,6 +5,8 @@ metadata:
   name: notes-job-mysql
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: notes
+    drydock.io/runner-service: mysql
   annotations:
     argocd.argoproj.io/sync-wave: "1"
     argocd.argoproj.io/hook: Sync
@@ -31,6 +33,8 @@ metadata:
   name: notes-job
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: notes
+    drydock.io/runner-service: notes
   annotations:
     argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/hook: Sync
@@ -63,6 +67,8 @@ metadata:
   name: notes-job-lms
   labels:
     app.kubernetes.io/component: job
+    drydock.io/target-service: notes
+    drydock.io/runner-service: lms
   annotations:
     argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/hook: Sync

--- a/drydock/templates/kustomized/tutor13/extensions/kustomization.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/kustomization.yml
@@ -30,3 +30,17 @@ configMapGenerator:
     labels:
         app.kubernetes.io/name: openedx
 {% endif -%}
+
+{% if not RUN_MYSQL -%}
+# MySQL job deletion based on the thread in https://github.com/kubernetes-sigs/kustomize/issues/4526
+patches:
+- target:
+    kind: Job
+    name: .*mysql.*
+  patch: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: does-not-matter
+    $patch: delete
+{%- endif %}

--- a/drydock/templates/kustomized/tutor13/extensions/kustomization.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/kustomization.yml
@@ -36,7 +36,7 @@ configMapGenerator:
 patches:
 - target:
     kind: Job
-    name: .*mysql.*
+    labelSelector: drydock.io/runner-service=mysql
   patch: |-
     apiVersion: batch/v1
     kind: Job


### PR DESCRIPTION
This PR configures a patch to remove all jobs whose name contains the word "mysql" when MySQL service is running outside the K8S cluster. This solution is based on the discussion on [this thread](https://github.com/kubernetes-sigs/kustomize/issues/4526).

I'm wondering if this solution is too wide, removing other jobs related to MySQL we would like to keep. Should we identify MySQL initialization tasks with an specific label? 