### PR TITLE
feat: Forum pod to W4, HPA to W5

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/hpa.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/hpa.yml
@@ -8,6 +8,8 @@ items:
   metadata:
     name: hpa-lms-deployment
     namespace: {{ K8S_NAMESPACE }}
+    annotations:
+      argocd.argoproj.io/sync-wave: "5"
   spec:
     maxReplicas: {{ DRYDOCK_LMS_MAX_REPLICAS }}
     minReplicas: {{ DRYDOCK_LMS_MIN_REPLICAS }}
@@ -21,6 +23,8 @@ items:
   metadata:
     name: hpa-cms-deployment
     namespace: {{ K8S_NAMESPACE }}
+    annotations:
+      argocd.argoproj.io/sync-wave: "5"
   spec:
     maxReplicas: {{ DRYDOCK_CMS_MAX_REPLICAS }}
     minReplicas: {{ DRYDOCK_CMS_MIN_REPLICAS }}
@@ -34,6 +38,8 @@ items:
   metadata:
     name: hpa-lms-worker-deployment
     namespace: {{ K8S_NAMESPACE }}
+    annotations:
+      argocd.argoproj.io/sync-wave: "5"
   spec:
     maxReplicas: {{ DRYDOCK_LMS_WORKERS_MAX_REPLICAS }}
     minReplicas: {{ DRYDOCK_LMS_WORKERS_MIN_REPLICAS }}
@@ -47,6 +53,8 @@ items:
   metadata:
     name: hpa-cms-worker-deployment
     namespace: {{ K8S_NAMESPACE }}
+    annotations:
+      argocd.argoproj.io/sync-wave: "5"
   spec:
     maxReplicas: {{ DRYDOCK_CMS_WORKERS_MAX_REPLICAS }}
     minReplicas: {{ DRYDOCK_CMS_WORKERS_MIN_REPLICAS }}

--- a/drydock/templates/kustomized/tutor13/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/overrides.yml
@@ -101,4 +101,13 @@ spec:
         name: newrelic-ini
 ---
 {% endif -%}
+{% if FORUM_DOCKER_IMAGE is defined %}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forum
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+---
+{% endif -%}
 {{ patch("drydock-overrides") }}


### PR DESCRIPTION
This PR aims to mitigate a couple of issues:

- Forum pod won't start appropriately unless the Forum initialization job has been run first. For this reason, I moved the Forum pod deployment to a later wave in argoCD (4)
- HPA resource creation fails if the deployments related to them are not yet created. This motivated the creation of a new wave (5) to apply the HPA.

At this point we are tightly coupled with ArgoCD, without it our initialization strategy won't work. Are we comfortable with this?