### PR TITLE
feat: multipurpose jobs

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/kustomization.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/kustomization.yml
@@ -20,6 +20,7 @@ resources:
 - drydock-jobs/notes.yml
 - drydock-jobs/extra-jobs.yml
 {%- endif %}
+- multipurpose-jobs.yml
 
 {% if DRYDOCK_NEWRELIC -%}
 configMapGenerator:

--- a/drydock/templates/kustomized/tutor13/extensions/multipurpose-jobs.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/multipurpose-jobs.yml
@@ -1,0 +1,1 @@
+{{ patch("drydock-multipurpose-jobs") }}


### PR DESCRIPTION
This PR adds a patch to enable multipurpose jobs in an OpenedX installation. This feature is thought to include jobs that are run regularly that are not part of the platform initialization. Examples of these tasks are:

- User retirement routines
- Old access tokens cleaning