### PR TITLE
feat: multipurpose jobs V14

### DIFF
--- a/drydock/templates/kustomized/tutor14/extensions/kustomization.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/kustomization.yml
@@ -20,6 +20,7 @@ resources:
 - drydock-jobs/notes.yml
 - drydock-jobs/extra-jobs.yml
 {%- endif %}
+- multipurpose-jobs.yml
 
 {% if DRYDOCK_NEWRELIC -%}
 configMapGenerator:

--- a/drydock/templates/kustomized/tutor14/extensions/multipurpose-jobs.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/multipurpose-jobs.yml
@@ -1,0 +1,1 @@
+{{ patch("drydock-multipurpose-jobs") }}


### PR DESCRIPTION
This PR adds a patch to enable multipurpose jobs in OpenedX installations generated with V14 templates. Quite similar to https://github.com/eduNEXT/drydock/pull/22