### PR TITLE
fix: add missing patch in V14 templates

### DIFF
--- a/drydock/templates/kustomized/tutor14/extensions/kustomization.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/kustomization.yml
@@ -31,3 +31,17 @@ configMapGenerator:
     labels:
         app.kubernetes.io/name: openedx
 {% endif -%}
+
+{% if not RUN_MYSQL -%}
+# MySQL job deletion based on the thread in https://github.com/kubernetes-sigs/kustomize/issues/4526
+patches:
+- target:
+    kind: Job
+    labelSelector: drydock.io/runner-service=mysql
+  patch: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: does-not-matter
+    $patch: delete
+{%- endif %}


### PR DESCRIPTION
## Description

The patch used to skip the MySQL initialization jobs when running the MySQL service outside of the Instance was missing.