### PR TITLE
feat: add configuration for container interactivity

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
@@ -42,6 +42,8 @@ spec:
               name: config
           securityContext:
             allowPrivilegeEscalation: false
+          stdin: true
+          tty: true
       volumes:
         - name: settings-lms
           configMap:
@@ -95,6 +97,8 @@ spec:
               name: config
           securityContext:
             allowPrivilegeEscalation: false
+          stdin: true
+          tty: true
       volumes:
         - name: settings-lms
           configMap:

--- a/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
@@ -40,6 +40,8 @@ spec:
               name: config
           securityContext:
             allowPrivilegeEscalation: false
+          stdin: true
+          tty: true
       volumes:
         - name: settings-lms
           configMap:
@@ -90,6 +92,8 @@ spec:
               name: config
           securityContext:
             allowPrivilegeEscalation: false
+          stdin: true
+          tty: true
       volumes:
         - name: settings-lms
           configMap:


### PR DESCRIPTION
### Description
This PR adds the needed configuration for container interactivity using tools like pudb/pdb for debugging purposes.

### How to test
1. After enabling the debugging services (check the instructions in [this PR](https://github.com/eduNEXT/drydock/pull/25) for a how to test), increase the number of replicas to 1 (if not already)
2. Enter the container, then install nano if needed
3. Modify `nano /openedx/edx-platform/common/djangoapps/student/views/dashboard.py` adding a breakpoint in the student_dashboard view (easy to test)
4. Attach to the container: `k attach -it lms-debug-XXXXX-XXXXX`
5. Enter the student dashboard