### PR TITLE
refactor: increase default debug replicas to at least one

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: cms-debug
@@ -62,7 +61,6 @@ metadata:
   labels:
     app.kubernetes.io/name: lms-debug
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: lms-debug

--- a/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: cms-debug
@@ -62,7 +62,7 @@ metadata:
   labels:
     app.kubernetes.io/name: lms-debug
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: lms-debug

--- a/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: cms-debug
@@ -62,7 +62,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: lms-debug

--- a/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
@@ -9,7 +9,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: cms-debug
@@ -62,7 +61,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: lms-debug


### PR DESCRIPTION
### Description
This PR increases the default number of replicas for the debug deployments to avoid issues with self-healing argocd configurations -so it doesn't remove the debugging pods while synchronizing-.