### PR TITLE
feat: add release GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-on: [push, workflow_dispatch]
+on: [workflow_dispatch]
 
 jobs:
   bumpversion:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-name: Bump version
-on: [workflow_dispatch]
+name: Release
+on: [push, workflow_dispatch]
 
 jobs:
   bumpversion:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Create bumpversion
         if: steps.tag_version.outputs.new_version
         run: |
-          pip install bumpversion
-          bumpversion --new-version ${{ steps.tag_version.outputs.new_version }} setup.cfg
+          pip install bump2version
+          bump2version --new-version ${{ steps.tag_version.outputs.new_version }} setup.cfg
       - name: Update Changelog
         if: steps.tag_version.outputs.new_version
         uses: stefanzweifel/changelog-updater-action@v1.6.2
@@ -65,4 +65,3 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Bump version
+on: [push, workflow_dispatch]
+
+jobs:
+  bumpversion:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag_version.outputs.new_version }}
+      previous_tag: ${{ steps.tag_version.outputs.previous_tag }}
+      bump_commit_sha: ${{ steps.bumpversion.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get next version
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          default_prerelease_bump: false
+          dry_run: true
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Create bumpversion
+        if: steps.tag_version.outputs.new_version
+        run: |
+          pip install bumpversion
+          bumpversion --new-version ${{ steps.tag_version.outputs.new_version }} setup.cfg
+      - name: Update Changelog
+        if: steps.tag_version.outputs.new_version
+        uses: stefanzweifel/changelog-updater-action@v1.6.2
+        with:
+          latest-version: ${{ steps.tag_version.outputs.new_tag }}
+          release-notes: ${{ steps.tag_version.outputs.changelog }}
+      - name: Commit bumpversion
+        id: bumpversion
+        if: steps.tag_version.outputs.new_version
+        uses: stefanzweifel/git-auto-commit-action@v4.14.1
+        with:
+          branch: ${{ github.ref }}
+          commit_message: "chore(release): preparing ${{ steps.tag_version.outputs.new_version }}"
+          file_pattern: setup.cfg CHANGELOG.md drydock/*
+  release:
+    needs: bumpversion
+    if: needs.bumpversion.outputs.version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ needs.bumpversion.outputs.bump_commit_sha }}
+          default_bump: false
+          default_prerelease_bump: false
+      - name: Create a GitHub release
+        if: steps.tag_version.outputs.new_tag
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           branch: ${{ github.ref }}
           commit_message: "chore(release): preparing ${{ steps.tag_version.outputs.new_version }}"
-          file_pattern: setup.cfg CHANGELOG.md drydock/*
+          file_pattern: CHANGELOG.md setup.cfg drydock/* tutor_plugin/*
   release:
     needs: bumpversion
     if: needs.bumpversion.outputs.version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Bump version
-on: [push, workflow_dispatch]
+on: [workflow_dispatch]
 
 jobs:
   bumpversion:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,89 +5,107 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/eduNEXT/drydock/compare/1.0.0...HEAD)
+## [Unreleased](https://github.com/eduNEXT/drydock/compare/v0.4.1...HEAD)
 
 Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
 
-## [0.4.1] - 2022-12-07
+## [0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) - 2022-12-07
 
-### Features
+### [0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) (2022-12-07)
+
+#### Features
 
 - Add configuration for container interactivity.
 
-### Code Refactoring
+#### Code Refactoring
 
 - Increase default debug replicas to at least one
 
-## [0.4.0] - 2022-12-01
+## [0.4.0](https://github.com/eduNEXT/drydock/compare/v0.3.4...v0.4.0) - 2022-12-01
 
-### Features
+### [0.4.0](https://github.com/eduNEXT/drydock/compare/v0.3.4...v0.4.0) (2022-12-01)
+
+#### Features
 
 - Add templates for debugging purposes.
 
-### Code Refactoring
+#### Code Refactoring
 
 - Check if forum is defined before adding resources.
 
-### Bug Fixes
+#### Bug Fixes
 
 - Use the right target for the forum hpa.
 - Add missing patch in V14 templates.
 
-## [0.3.4] - 2022-11-09
+## [0.3.4](https://github.com/eduNEXT/drydock/compare/v0.3.3...v0.3.4) - 2022-11-09
 
-### Features
+### [0.3.4](https://github.com/eduNEXT/drydock/compare/v0.3.3...v0.3.4) (2022-11-09)
+
+#### Features
 
 - Add multipurpose jobs for tutor version 14.
 
-## [0.3.3] - 2022-11-09
+## [0.3.3](https://github.com/eduNEXT/drydock/compare/v0.3.2...v0.3.3) - 2022-11-09
 
-### Features
+### [0.3.3](https://github.com/eduNEXT/drydock/compare/v0.3.2...v0.3.3) (2022-11-09)
+
+#### Features
 
 - Add multipurpose jobs.
 
-## [0.3.2] - 2022-11-09
+## [0.3.2](https://github.com/eduNEXT/drydock/compare/v0.3.1...v0.3.2) - 2022-11-09
 
-### Bug Fixes
+### [0.3.2](https://github.com/eduNEXT/drydock/compare/v0.3.1...v0.3.2) (2022-11-09)
+
+#### Bug Fixes
 
 - Add missing labels for notes jobs.
 
-## [0.3.1] - 2022-10-21
+## [0.3.1](https://github.com/eduNEXT/drydock/compare/v0.3.0...v0.3.1) - 2022-10-21
 
-### Code Refactoring
+### [0.3.1](https://github.com/eduNEXT/drydock/compare/v0.3.0...v0.3.1) (2022-10-21)
+
+#### Code Refactoring
 
 - Refactor hpa with latest practices.
 
-## [0.3.0] - 2022-10-18
+## [0.3.0](https://github.com/eduNEXT/drydock/compare/v0.2.0...v0.3.0) - 2022-10-18
 
-### Features
+### [0.3.0](https://github.com/eduNEXT/drydock/compare/v0.2.0...v0.3.0) (2022-10-18)
+
+#### Features
 
 - Make manifests template root configurable through reference.
 - Add templates with tutor14 support.
 
-## [0.2.0] - 2022-10-13
+## [0.2.0](https://github.com/eduNEXT/drydock/compare/v0.1.0...v0.2.0) - 2022-10-13
 
-### Features
+### [0.2.0](https://github.com/eduNEXT/drydock/compare/v0.1.0...v0.2.0) (2022-10-13)
+
+#### Features
 
 - Add 1st version of rendered jobs.
 - Add toggleable certificates.
 - Add extra-jobs for extra tasks during initialization.
 
-### Bug fixes
+#### Bug fixes
 
 - Use production ingress instead of dummy.
 - Use the correct init command for forum and add missing annotations.
 
-### Code Refactoring
+#### Code Refactoring
 
 - Move forum pod to wave 4, HPA to wave 5.
 - Remove MySQL jobs when MySQL running outside the cluster.
 
 ## [0.1.0] - 2022-10-12
 
-### Features
+### [0.1.0] (2022-10-12)
+
+#### Features
 
 - Add a basic manifest repository implementation.
 - Add kustomize based extensions to the base manifests.
@@ -95,6 +113,6 @@ Please do not update the unreleased notes.
 - Render global environment outside tutor-env.
 - Add support for custom SSL certificates.
 
-### Bug fixes
+#### Bug fixes
 
 - Set a default value for DRYDOCK_NEWRELIC_CONFIG variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/eduNEXT/drydock/compare/1.0.0...HEAD)
+
+Please do not update the unreleased notes.
+
+<!-- Content should be placed here -->
+
+## [0.4.1] - 2022-12-07
+
+### Features
+
+- Add configuration for container interactivity.
+
+### Code Refactoring
+
+- Increase default debug replicas to at least one
+
+## [0.4.0] - 2022-12-01
+
+### Features
+
+- Add templates for debugging purposes.
+
+### Code Refactoring
+
+- Check if forum is defined before adding resources.
+
+### Bug Fixes
+
+- Use the right target for the forum hpa.
+- Add missing patch in V14 templates.
+
+## [0.3.4] - 2022-11-09
+
+### Features
+
+- Add multipurpose jobs for tutor version 14.
+
+## [0.3.3] - 2022-11-09
+
+### Features
+
+- Add multipurpose jobs.
+
+## [0.3.2] - 2022-11-09
+
+### Bug Fixes
+
+- Add missing labels for notes jobs.
+
+## [0.3.1] - 2022-10-21
+
+### Code Refactoring
+
+- Refactor hpa with latest practices.
+
+## [0.3.0] - 2022-10-18
+
+### Features
+
+- Make manifests template root configurable through reference.
+- Add templates with tutor14 support.
+
+## [0.2.0] - 2022-10-13
+
+### Features
+
+- Add 1st version of rendered jobs.
+- Add toggleable certificates.
+- Add extra-jobs for extra tasks during initialization.
+
+### Bug fixes
+
+- Use production ingress instead of dummy.
+- Use the correct init command for forum and add missing annotations.
+
+### Code Refactoring
+
+- Move forum pod to wave 4, HPA to wave 5.
+- Remove MySQL jobs when MySQL running outside the cluster.
+
+## [0.1.0] - 2022-10-12
+
+### Features
+
+- Add a basic manifest repository implementation.
+- Add kustomize based extensions to the base manifests.
+- Add newrelic manifests for tutor13 installation.
+- Render global environment outside tutor-env.
+- Add support for custom SSL certificates.
+
+### Bug fixes
+
+- Set a default value for DRYDOCK_NEWRELIC_CONFIG variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
-
 ## [0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) - 2022-12-07
 
 ### [0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) (2022-12-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please do not update the unreleased notes.
 
 <!-- Content should be placed here -->
-## [0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) - 2022-12-07
+## [v0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) - 2022-12-07
 
 ### [0.4.1](https://github.com/eduNEXT/drydock/compare/v0.4.0...v0.4.1) (2022-12-07)
 
@@ -22,7 +22,7 @@ Please do not update the unreleased notes.
 
 - Increase default debug replicas to at least one
 
-## [0.4.0](https://github.com/eduNEXT/drydock/compare/v0.3.4...v0.4.0) - 2022-12-01
+## [v0.4.0](https://github.com/eduNEXT/drydock/compare/v0.3.4...v0.4.0) - 2022-12-01
 
 ### [0.4.0](https://github.com/eduNEXT/drydock/compare/v0.3.4...v0.4.0) (2022-12-01)
 
@@ -39,7 +39,7 @@ Please do not update the unreleased notes.
 - Use the right target for the forum hpa.
 - Add missing patch in V14 templates.
 
-## [0.3.4](https://github.com/eduNEXT/drydock/compare/v0.3.3...v0.3.4) - 2022-11-09
+## [v0.3.4](https://github.com/eduNEXT/drydock/compare/v0.3.3...v0.3.4) - 2022-11-09
 
 ### [0.3.4](https://github.com/eduNEXT/drydock/compare/v0.3.3...v0.3.4) (2022-11-09)
 
@@ -47,7 +47,7 @@ Please do not update the unreleased notes.
 
 - Add multipurpose jobs for tutor version 14.
 
-## [0.3.3](https://github.com/eduNEXT/drydock/compare/v0.3.2...v0.3.3) - 2022-11-09
+## [v0.3.3](https://github.com/eduNEXT/drydock/compare/v0.3.2...v0.3.3) - 2022-11-09
 
 ### [0.3.3](https://github.com/eduNEXT/drydock/compare/v0.3.2...v0.3.3) (2022-11-09)
 
@@ -55,7 +55,7 @@ Please do not update the unreleased notes.
 
 - Add multipurpose jobs.
 
-## [0.3.2](https://github.com/eduNEXT/drydock/compare/v0.3.1...v0.3.2) - 2022-11-09
+## [v0.3.2](https://github.com/eduNEXT/drydock/compare/v0.3.1...v0.3.2) - 2022-11-09
 
 ### [0.3.2](https://github.com/eduNEXT/drydock/compare/v0.3.1...v0.3.2) (2022-11-09)
 
@@ -63,7 +63,7 @@ Please do not update the unreleased notes.
 
 - Add missing labels for notes jobs.
 
-## [0.3.1](https://github.com/eduNEXT/drydock/compare/v0.3.0...v0.3.1) - 2022-10-21
+## [v0.3.1](https://github.com/eduNEXT/drydock/compare/v0.3.0...v0.3.1) - 2022-10-21
 
 ### [0.3.1](https://github.com/eduNEXT/drydock/compare/v0.3.0...v0.3.1) (2022-10-21)
 
@@ -71,7 +71,7 @@ Please do not update the unreleased notes.
 
 - Refactor hpa with latest practices.
 
-## [0.3.0](https://github.com/eduNEXT/drydock/compare/v0.2.0...v0.3.0) - 2022-10-18
+## [v0.3.0](https://github.com/eduNEXT/drydock/compare/v0.2.0...v0.3.0) - 2022-10-18
 
 ### [0.3.0](https://github.com/eduNEXT/drydock/compare/v0.2.0...v0.3.0) (2022-10-18)
 
@@ -80,7 +80,7 @@ Please do not update the unreleased notes.
 - Make manifests template root configurable through reference.
 - Add templates with tutor14 support.
 
-## [0.2.0](https://github.com/eduNEXT/drydock/compare/v0.1.0...v0.2.0) - 2022-10-13
+## [v0.2.0](https://github.com/eduNEXT/drydock/compare/v0.1.0...v0.2.0) - 2022-10-13
 
 ### [0.2.0](https://github.com/eduNEXT/drydock/compare/v0.1.0...v0.2.0) (2022-10-13)
 
@@ -100,9 +100,9 @@ Please do not update the unreleased notes.
 - Move forum pod to wave 4, HPA to wave 5.
 - Remove MySQL jobs when MySQL running outside the cluster.
 
-## [0.1.0] - 2022-10-12
+## [v0.1.0](https://github.com/eduNEXT/drydock/commits/v0.1.0) - 2022-10-12
 
-### [0.1.0] (2022-10-12)
+### [0.1.0](https://github.com/eduNEXT/drydock/commits/v0.1.0) (2022-10-12)
 
 #### Features
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ current_version = 0.4.1
 commit = False
 tag = False
 
-[bumpversion:file:drydock/tutor_plugin/__about__.py]
+[bumpversion:file:tutor_plugin/__about__.py]
 
 [isort]
 include_trailing_comma = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[bumpversion]
+current_version = 0.4.1
+commit = False
+tag = False
+
+[bumpversion:file:drydock/tutor_plugin/__about__.py]
+
+[isort]
+include_trailing_comma = True
+indent = '    '
+line_length = 120
+multi_line_output = 3
+
+[wheel]
+universal = 1


### PR DESCRIPTION
### Description
This PR adds a github workflow triggered manually by shipyard maintainers:

1. Executes a dryrun to obtain the next tag version
2. Based on the next tag version, generates the new changelog entry
3. Uses bumpversion library to update strings in the library
4. Executes again the action that generates the tag, this time it pushes the tag to the main branchry
5. Generates a draft release

This workflow can be changed based on what we want our release workflow to be, I'm open to suggestions.