### PR TITLE
chore: adding backstage catalog and owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# global owners of all the code in this repo
+* @eduNEXT/shipyard-crew

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: Drydock
+  description: Template library for manifests
+spec:
+  type: library
+  owner: shipyard-crew
+  lifecycle: production


### PR DESCRIPTION
This PR adds a basic catalog and assigns the code to @eduNEXT/shipyard-crew 