### PR TITLE
Small fixes: CMS_SSO_USER, cms debug pods and whitespace triming

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/lms.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/drydock-jobs/lms.yml
@@ -42,7 +42,7 @@ spec:
             --client-secret {{ CMS_OAUTH2_SECRET }} \
             --scopes user_id \
             --skip-authorization \
-            --update cms-sso cms-sso-user
+            --update cms-sso {{ DRYDOCK_CMS_SSO_USER }}
 
           # Fix incorrect uploaded file path
           if [ -d /openedx/data/uploads/ ]; then

--- a/drydock/templates/kustomized/tutor13/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/overrides.yml
@@ -84,10 +84,10 @@ spec:
             requests:
               cpu: "{{ DRYDOCK_FORUM_REQUEST_CPU }}"
               memory: "{{ DRYDOCK_FORUM_REQUEST_MEMORY }}"
-{% endif -%}
+{%- endif %}
 ---
-{% endif -%}
-{%- if DRYDOCK_NEWRELIC -%}
+{%- endif %}
+{%- if DRYDOCK_NEWRELIC %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -119,8 +119,8 @@ spec:
           name: newrelic-cm
         name: newrelic-ini
 ---
-{% endif -%}
-{% if FORUM_DOCKER_IMAGE is defined %}
+{%- endif %}
+{%- if FORUM_DOCKER_IMAGE is defined %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -128,5 +128,5 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
 ---
-{% endif -%}
+{%- endif %}
 {{ patch("drydock-overrides") }}

--- a/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
@@ -28,6 +28,8 @@ spec:
           env:
           - name: SERVICE_VARIANT
             value: cms
+          - name: DJANGO_SETTINGS_MODULE
+            value: cms.envs.tutor.production
           ports:
             - containerPort: 8000
           volumeMounts:

--- a/drydock/templates/kustomized/tutor14/extensions/drydock-jobs/lms.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/drydock-jobs/lms.yml
@@ -42,7 +42,7 @@ spec:
             --client-secret {{ CMS_OAUTH2_SECRET }} \
             --scopes user_id \
             --skip-authorization \
-            --update cms-sso cms-sso-user
+            --update cms-sso {{ DRYDOCK_CMS_SSO_USER }}
 
           # Fix incorrect uploaded file path
           if [ -d /openedx/data/uploads/ ]; then

--- a/drydock/templates/kustomized/tutor14/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/overrides.yml
@@ -84,9 +84,9 @@ spec:
             requests:
               cpu: "{{ DRYDOCK_FORUM_REQUEST_CPU }}"
               memory: "{{ DRYDOCK_FORUM_REQUEST_MEMORY }}"
-{% endif -%}
+{%- endif %}
 ---
-{% endif -%}
+{%- endif %}
 {%- if DRYDOCK_NEWRELIC -%}
 apiVersion: apps/v1
 kind: Deployment
@@ -119,8 +119,8 @@ spec:
           name: newrelic-cm
         name: newrelic-ini
 ---
-{% endif -%}
-{% if FORUM_DOCKER_IMAGE is defined %}
+{%- endif %}
+{%- if FORUM_DOCKER_IMAGE is defined %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -128,5 +128,5 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
 ---
-{% endif -%}
+{%- endif %}
 {{ patch("drydock-overrides") }}

--- a/drydock/templates/kustomized/tutor15/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor15/extensions/debug/deployments.yml
@@ -28,6 +28,8 @@ spec:
           env:
           - name: SERVICE_VARIANT
             value: cms
+          - name: DJANGO_SETTINGS_MODULE
+            value: cms.envs.tutor.production
           ports:
             - containerPort: 8000
           volumeMounts:


### PR DESCRIPTION
## Description

A compilation of small fixes that address:

- cms debug pods don't define the `DJANGO_SETTINGS_MODULE` variable.
- The `DRYDOCK_CMS_SSO_USER` variable is not being used in the actual command.
- Triming whitespace in certain places generates invalid yaml.