### PR TITLE
fix: rendering NewRelic overrides properly in tutor14 Drydock templates

### DIFF
--- a/drydock/templates/kustomized/tutor14/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/overrides.yml
@@ -87,7 +87,7 @@ spec:
 {%- endif %}
 ---
 {%- endif %}
-{%- if DRYDOCK_NEWRELIC -%}
+{%- if DRYDOCK_NEWRELIC %}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This PR fixes an issue when rendering Drydock overrides for NewRelic. Without this change, the output looks like this:

`---apiVersion: apps/v1`

which breaks the YAML format.