### PR TITLE
fix: set the correct path to use pvc volume

### DIFF
--- a/drydock_backups/Dockerfile
+++ b/drydock_backups/Dockerfile
@@ -16,6 +16,8 @@ RUN echo "backupuser ALL=(ALL) NOPASSWD: /usr/bin/mysql, /usr/bin/mongodump" >> 
 
 USER backupuser
 
-WORKDIR /home/backupuser
+WORKDIR /data
 
-RUN echo
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/drydock_backups/docker-entrypoint.sh
+++ b/drydock_backups/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+set -eo pipefail
+
+FILENAME="$(date +'%Y-%m-%d').gz"
+
+if [ "$1" = 'mysql' ]; then
+      echo "1"
+      mysqldump -u $MYSQL_ROOT_USERNAME -h $MYSQL_HOST -P $MYSQL_PORT --password=$MYSQL_ROOT_PASSWORD \
+            --all-databases --single-transaction --flush-logs | gzip > $FILENAME
+elif [ "$1" = 'mongo' ]; then
+      if [[ -z "${MONGODB_USERNAME}" ]]; then
+            mongodump \
+            --host $MONGODB_HOST:$MONGODB_PORT \
+            -d $MONGODB_DATABASES --gzip \
+            --archive=$FILENAME
+      else
+            mongodump --username $MONGODB_USERNAME --password $MONGODB_PASSWORD --authenticationDatabase=admin \
+            --host $MONGODB_HOST:$MONGODB_PORT \
+            -d $MONGODB_DATABASES --gzip \
+            --archive=$FILENAME
+      fi
+else
+    echo "Unknown database type"
+    exit 1
+fi
+
+if [[ -z "${BACKUP_CUSTOM_STORAGE_ENDPOINT}" ]]; then
+      aws s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/$1/
+else
+      aws -endpoint-url $BACKUP_CUSTOM_STORAGE_ENDPOINT s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/$1/
+fi

--- a/drydock_backups/docker-entrypoint.sh
+++ b/drydock_backups/docker-entrypoint.sh
@@ -4,22 +4,22 @@ set -eo pipefail
 
 FILENAME="$(date +'%Y-%m-%d').gz"
 
+MONGODB_URI="mongodb://"
+MONGODB_PORT=${MONGODB_PORT:-27017}
+MONGODB_HOST=${MONGODB_HOST:-mongodb}
+MONGODB_AUTHDB=${MONGODB_AUTHDB:-admin}
+
+if [ -n "${MONGODB_USERNAME}" ] && [ -n "${MONGODB_PASSWORD}" ]; then
+    MONGODB_URI+="${MONGODB_USERNAME}:${MONGODB_PASSWORD}@"
+fi
+
+MONGODB_URI+="${MONGODB_HOST}:${MONGODB_PORT}/${MONGODB_DATABASES}?authSource=${MONGODB_AUTHDB}"
+
 if [ "$1" = 'mysql' ]; then
-      echo "1"
       mysqldump -u $MYSQL_ROOT_USERNAME -h $MYSQL_HOST -P $MYSQL_PORT --password=$MYSQL_ROOT_PASSWORD \
             --all-databases --single-transaction --flush-logs | gzip > $FILENAME
 elif [ "$1" = 'mongo' ]; then
-      if [[ -z "${MONGODB_USERNAME}" ]]; then
-            mongodump \
-            --host $MONGODB_HOST:$MONGODB_PORT \
-            -d $MONGODB_DATABASES --gzip \
-            --archive=$FILENAME
-      else
-            mongodump --username $MONGODB_USERNAME --password $MONGODB_PASSWORD --authenticationDatabase=admin \
-            --host $MONGODB_HOST:$MONGODB_PORT \
-            -d $MONGODB_DATABASES --gzip \
-            --archive=$FILENAME
-      fi
+      mongodump --uri="${MONGODB_URI}" --gzip --archive=$FILENAME
 else
     echo "Unknown database type"
     exit 1

--- a/drydock_backups/docker-entrypoint.sh
+++ b/drydock_backups/docker-entrypoint.sh
@@ -28,5 +28,5 @@ fi
 if [[ -z "${BACKUP_CUSTOM_STORAGE_ENDPOINT}" ]]; then
       aws s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/$1/
 else
-      aws -endpoint-url $BACKUP_CUSTOM_STORAGE_ENDPOINT s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/$1/
+      aws --endpoint-url $BACKUP_CUSTOM_STORAGE_ENDPOINT s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/$1/
 fi

--- a/drydock_backups/patches/drydock-multipurpose-jobs
+++ b/drydock_backups/patches/drydock-multipurpose-jobs
@@ -100,7 +100,7 @@ spec:
                 - name: MONGODB_PASSWORD
                   value: '{{ BACKUP_MONGO_PASSWORD }}'
                 - name: MONGODB_DATABASES
-                  value: '{{ MONGODB_DATABASE }}'
+                  value: '{{ BACKUP_MONGODB_DATABASE }}'
                 - name: AWS_ACCESS_KEY_ID
                   value: '{{ BACKUP_AWS_ACCESS_KEY }}'
                 - name: AWS_SECRET_ACCESS_KEY

--- a/drydock_backups/patches/drydock-multipurpose-jobs
+++ b/drydock_backups/patches/drydock-multipurpose-jobs
@@ -15,6 +15,11 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
           restartPolicy: OnFailure
           containers:
             - name: backup
@@ -45,11 +50,8 @@ spec:
                 - mountPath: /data/
                   name: backup-volume
               {% endif %}
-              command: ["/bin/sh", "-c"]
-              args: ["FILENAME=$(date +'%Y-%m-%d').sql.gz && \
-                    mysqldump -u $MYSQL_ROOT_USERNAME -h $MYSQL_HOST -P $MYSQL_PORT \
-                    --password=$MYSQL_ROOT_PASSWORD --all-databases --single-transaction --flush-logs \
-                    | gzip > $FILENAME && aws {% if BACKUP_CUSTOM_STORAGE_ENDPOINT %} --endpoint-url $BACKUP_CUSTOM_STORAGE_ENDPOINT {% endif %} s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/mysql/"]
+              args:
+                - mysql
           {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
           volumes:
             - name: backup-volume
@@ -79,6 +81,11 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
           restartPolicy: OnFailure
           containers:
             - name: backup
@@ -111,12 +118,8 @@ spec:
                 - mountPath: /data/
                   name: backup-volume
               {% endif %}
-              command: ["/bin/sh", "-c"]
-              args: ["FILENAME=$(date +'%Y-%m-%d').gz && \
-              mongodump {% if MONGODB_USERNAME %} --username $MONGODB_USERNAME --password $MONGODB_PASSWORD --authenticationDatabase=admin {% endif %}\
-              --host $MONGODB_HOST:$MONGODB_PORT \
-              -d $MONGODB_DATABASES --gzip \
-              --archive=$FILENAME && aws {% if BACKUP_CUSTOM_STORAGE_ENDPOINT %} --endpoint-url $BACKUP_CUSTOM_STORAGE_ENDPOINT {% endif %} s3 mv $FILENAME s3://$S3_BUCKET_NAME/$BUCKET_PATH/mongo/"]
+              args:
+                - mongo
           {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
           volumes:
             - name: backup-volume

--- a/drydock_backups/plugin.py
+++ b/drydock_backups/plugin.py
@@ -26,7 +26,7 @@ config = {
         "MYSQL_PASSWORD": '{{ MYSQL_ROOT_PASSWORD }}',
         "MONGO_PASSWORD": '{{ MONGODB_PASSWORD }}',
         "MONGO_USERNAME": '{{ MONGODB_USERNAME }}',
-        "MONGODB_DATABASE": None
+        "MONGODB_DATABASE": ""
     },
 }
 

--- a/drydock_backups/plugin.py
+++ b/drydock_backups/plugin.py
@@ -25,7 +25,8 @@ config = {
         "MYSQL_USERNAME": '{{ MYSQL_ROOT_USERNAME }}',
         "MYSQL_PASSWORD": '{{ MYSQL_ROOT_PASSWORD }}',
         "MONGO_PASSWORD": '{{ MONGODB_PASSWORD }}',
-        "MONGO_USERNAME": '{{ MONGODB_USERNAME }}'
+        "MONGO_USERNAME": '{{ MONGODB_USERNAME }}',
+        "MONGODB_DATABASE": None
     },
 }
 


### PR DESCRIPTION
# Description

This PR fixes the path to use in db backup to /data which is mounted by PVC. 

Also changes the cronjob to just run the docker entrypoint with arg and changes the docker image.


# Test

I was testing on [yamato-dunkirk](https://argocd.services.stage.edunext-shipyard.net/applications/dunkerque-openedx?operation=false&resource=)