### PR TITLE
feat: add flag to load static debug server

### DIFF
--- a/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/debug/deployments.yml
@@ -22,8 +22,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: cms-debug
-          args: [./manage.py cms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py cms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           env:
           - name: SERVICE_VARIANT
@@ -76,8 +79,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: lms-debug
-          args: [./manage.py lms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py lms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           env:
           - name: SERVICE_VARIANT

--- a/drydock/templates/kustomized/tutor13/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor13/extensions/overrides.yml
@@ -107,7 +107,9 @@ spec:
               --processes=${UWSGI_WORKERS:-2} \
               --buffer-size=8192 \
               --wsgi-file $SERVICE_VARIANT/wsgi.py
-          command: ["/bin/bash", "-c"]
+          command: 
+            - "/bin/bash"
+            - "-c"
           env:
           - name: NEW_RELIC_CONFIG_FILE
             value: /openedx/newrelic/newrelic.ini

--- a/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/debug/deployments.yml
@@ -22,8 +22,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: cms-debug
-          args: [./manage.py cms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py cms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           env:
           - name: SERVICE_VARIANT
@@ -78,8 +81,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: lms-debug
-          args: [./manage.py lms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py lms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           ports:
             - containerPort: 8000

--- a/drydock/templates/kustomized/tutor14/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor14/extensions/overrides.yml
@@ -107,7 +107,9 @@ spec:
               --processes=${UWSGI_WORKERS:-2} \
               --buffer-size=8192 \
               --wsgi-file $SERVICE_VARIANT/wsgi.py
-          command: ["/bin/bash", "-c"]
+          command: 
+            - "/bin/bash"
+            - "-c"
           env:
           - name: NEW_RELIC_CONFIG_FILE
             value: /openedx/newrelic/newrelic.ini

--- a/drydock/templates/kustomized/tutor15/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor15/extensions/debug/deployments.yml
@@ -22,8 +22,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: cms-debug
-          args: [./manage.py cms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py cms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           env:
           - name: SERVICE_VARIANT
@@ -78,8 +81,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: lms-debug
-          args: [./manage.py lms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py lms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           ports:
             - containerPort: 8000

--- a/drydock/templates/kustomized/tutor15/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor15/extensions/overrides.yml
@@ -107,7 +107,9 @@ spec:
               --processes=${UWSGI_WORKERS:-2} \
               --buffer-size=8192 \
               --wsgi-file $SERVICE_VARIANT/wsgi.py
-          command: ["/bin/bash", "-c"]
+          command: 
+            - "/bin/bash"
+            - "-c"
           env:
           - name: NEW_RELIC_CONFIG_FILE
             value: /openedx/newrelic/newrelic.ini

--- a/drydock/templates/kustomized/tutor16/extensions/debug/deployments.yml
+++ b/drydock/templates/kustomized/tutor16/extensions/debug/deployments.yml
@@ -21,8 +21,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: cms-debug
-          args: [./manage.py cms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py cms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           env:
           - name: SERVICE_VARIANT
@@ -75,8 +78,11 @@ spec:
         runAsGroup: 0
       containers:
         - name: lms-debug
-          args: [./manage.py lms runserver 0.0.0.0:8000]
-          command: ["/bin/bash", "-c"]
+          args: 
+            - ./manage.py lms runserver 0.0.0.0:8000 --insecure
+          command: 
+            - "/bin/bash"
+            - "-c"
           image: {{ DOCKER_IMAGE_OPENEDX }}
           ports:
             - containerPort: 8000

--- a/drydock/templates/kustomized/tutor16/extensions/overrides.yml
+++ b/drydock/templates/kustomized/tutor16/extensions/overrides.yml
@@ -107,7 +107,9 @@ spec:
               --processes=${UWSGI_WORKERS:-2} \
               --buffer-size=8192 \
               --wsgi-file $SERVICE_VARIANT/wsgi.py
-          command: ["/bin/bash", "-c"]
+          command: 
+            - "/bin/bash"
+            - "-c"
           env:
           - name: NEW_RELIC_CONFIG_FILE
             value: /openedx/newrelic/newrelic.ini


### PR DESCRIPTION
# Description
The `--insecure` flag allow to load static from debug server using the runserver command. https://github.com/django/django/blob/stable/3.2.x/django/contrib/staticfiles/management/commands/runserver.py#L17-L19