### PR TITLE
fix: remove pat from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
       bump_commit_sha: ${{ steps.bumpversion.outputs.commit_hash }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ATLAS_PAT }}
       - name: Get next version
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0
@@ -52,8 +50,6 @@ jobs:
       changelog: ${{ steps.tag_version.outputs.changelog }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ATLAS_PAT }}
       - name: Create tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0


### PR DESCRIPTION
# Description

This PR removes unused ATLAS_PAT due to we're currently have the main branch unprotected.