### PR TITLE
fix: issue at first run with lms and cms deployments

### DIFF
--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -17,7 +17,7 @@ patches:
 # Patch the sync waves
 - target:
     kind: Deployment
-    name:  "lms-worker|cms-worker|forum"
+    name:  "lms|cms|lms-worker|cms-worker|forum"
   path: plugins/drydock/k8s/patches/sync-wave-4.yml
 {%- if DRYDOCK_DEBUG is defined and DRYDOCK_DEBUG %}
 - target:


### PR DESCRIPTION
# Description

Currently, the first initialization of the "LMS" and "CMS" deployment modules fails when trying to look up tables before they were migrated in the jobs with ArgoCD  Waves. This PR fixes the issue by placing these two deployments in the fourth wave after the jobs were run.