### PR TITLE
fix: add manifests file to allow install drydock non editable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include drydock/patches *
+recursive-include drydock/templates *
+include requirements/constraints.txt


### PR DESCRIPTION
# Description

This PR adds MANIFESTS file to allow install drydock as non editable