### PR TITLE
feat: add support to quince

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=16.0.0,<17.0.0"],
+    install_requires=["tutor>=17.0.0,<18.0.0"],
     entry_points={"tutor.plugin.v1": ["drydock = drydock.plugin"]
     },
     classifiers=[


### PR DESCRIPTION
# Description

This PR adds support to quince in drydock.

There is an environment synced and working on https://argocd.services.stage.edunext-shipyard.net/applications/argocd/quince-openedx?view=tree&resource=