### PR TITLE
fix: indent patch drydock-mongodb-init-job

### DIFF
--- a/drydock/templates/drydock/k8s/drydock-jobs/mongodb.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mongodb.yml
@@ -44,6 +44,6 @@ spec:
               })
             }
             {%- endif %}
-            {{ patch("drydock-mongodb-init-job") }}
+            {{ patch("drydock-mongodb-init-job"|indent(12)) }}
             exit
           EOF


### PR DESCRIPTION
### Description

indent patch `drydock-mongodb-init-job` to be a valid yaml