### PR TITLE
fix: notes annotations throw job skip from argocd sync

### DIFF
--- a/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
@@ -32,7 +32,7 @@ kind: Job
 metadata:
   name: drydock-notes-job
   labels:
-    app.kubernetes.io/component: job
+    drydock.io/component: job
     drydock.io/target-service: notes
     drydock.io/runner-service: notes
   annotations:
@@ -66,7 +66,7 @@ kind: Job
 metadata:
   name: drydock-notes-job-lms
   labels:
-    app.kubernetes.io/component: job
+    drydock.io/component: job
     drydock.io/target-service: notes
     drydock.io/runner-service: lms
   annotations:


### PR DESCRIPTION
# Description

Default tutor jobs are skipped due to an error with ArgoCD, the skip match is based on `app.kubernetes.io/component: job`, there are some missing annotations that need to be fixed in this PR.