### PR TITLE
feat: add forum variables support, mfe init jobs and migration jobs

### DIFF
--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -14,19 +14,14 @@ patches:
     labelSelector: app.kubernetes.io/component=job
   path: plugins/drydock/k8s/patches/tutor-jobs.yml
 # Patch the sync waves
-- target:
-    kind: Deployment
-    name:  "lms|cms|lms-worker|cms-worker|forum"
-  path: plugins/drydock/k8s/patches/sync-wave-4.yml
-{%- if DRYDOCK_DEBUG is defined and DRYDOCK_DEBUG %}
-- target:
-    kind: Deployment|Ingress|Service
-    name:  "cms-debug|lms-debug|ingress-debug"
-  path: plugins/drydock/k8s/patches/sync-wave-5.yml
-{%- endif %}
+- path: plugins/drydock/k8s/sync-waves/lms.yml
+- path: plugins/drydock/k8s/sync-waves/cms.yml
+- path: plugins/drydock/k8s/sync-waves/cms-worker.yml
+- path: plugins/drydock/k8s/sync-waves/lms-worker.yml
+- path: plugins/drydock/k8s/sync-waves/forum.yml
 - target:
     kind: HorizontalPodAutoscaler
-  path: plugins/drydock/k8s/patches/sync-wave-5.yml
+  path: plugins/drydock/k8s/patches/sync-wave-100.yml
 {% if DRYDOCK_ENABLE_CELERY_TUNING %}
 - path: plugins/drydock/k8s/celery/cms-worker.yml
 - path: plugins/drydock/k8s/celery/lms-worker.yml

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -31,3 +31,6 @@ patches:
 - path: plugins/drydock/k8s/celery/cms-worker.yml
 - path: plugins/drydock/k8s/celery/lms-worker.yml
 {% endif -%}
+{% if FORUM_USERNAME is defined and FORUM_PASSWORD is defined %}
+- path: plugins/drydock/k8s/patches/forum.yml
+{% endif -%}

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -1,4 +1,14 @@
 - plugins/drydock/k8s/multipurpose-jobs.yml
+{% if 'maple' in get_migration_list() %}
+- plugins/drydock/k8s/migration-jobs/maple/lms.yml
+- plugins/drydock/k8s/migration-jobs/maple/cms.yml
+{% endif %}
+{% if 'nutmeg' in get_migration_list() %}
+- plugins/drydock/k8s/migration-jobs/nutmeg/lms.yml
+{% endif %}
+{% if 'olive' in get_migration_list() %}
+- plugins/drydock/k8s/migration-jobs/olive/lms.yml
+{% endif %}
 {%- if DRYDOCK_INIT_JOBS %}
 - plugins/drydock/k8s/drydock-jobs/mysql.yml
 - plugins/drydock/k8s/drydock-jobs/mongodb.yml

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -7,6 +7,7 @@
 - plugins/drydock/k8s/drydock-jobs/minio.yml
 - plugins/drydock/k8s/drydock-jobs/forum.yml
 - plugins/drydock/k8s/drydock-jobs/notes.yml
+- plugins/drydock/k8s/drydock-jobs/mfe.yml
 {%- endif %}
 {% if DRYDOCK_FLOWER -%}
 - plugins/drydock/k8s/flower.yml

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -21,11 +21,13 @@ PRIORITY_LIST = [
     ('job', 'migration-olive-lms-job'),
 
     ('job', 'drydock-mysql-job'),
-    ('job', 'drydock-notes-job-mysql'),
     ('job', 'drydock-mongodb-job'),
+    ('job', 'drydock-lms-job'),
+    ('job', 'drydock-notes-job-mysql'),
+    ('job', 'drydock-notes-job-lms'),
+    ('job', 'drydock-notes-job'),
     ('job', 'drydock-minio-job'),
     ('job', 'drydock-mfe-lms-job'),
-    ('job', 'drydock-lms-job'),
     ('job', 'drydock-forum-job'),
     ('job', 'drydock-cms-job'),
 
@@ -93,6 +95,8 @@ def get_migration_list():
     settings.
     """
     migration_list = []
+    if not config["defaults"]["MIGRATE_FROM"]:
+        return migration_list
     migrate_from = config["defaults"]["MIGRATE_FROM"]
     migrate_to = config['defaults']['VERSION'].split('.', maxsplit=1)[0]
     for name, version in VERSION_LIST:

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -6,6 +6,50 @@ from tutor import hooks
 
 from .__about__ import __version__
 
+VERSION_LIST = [
+    ('MAPLE', '13'),
+    ('NUTMEG', '14'),
+    ('OLIVE', '15'),
+    ('PALM', '16'),
+    ('QUINCE', '17'),
+]
+
+PRIORITY_LIST = [
+    ('job', 'migration-maple-lms-job'),
+    ('job', 'migration-maple-cms-job'),
+    ('job', 'migration-nutmeg-lms-job'),
+    ('job', 'migration-olive-lms-job'),
+
+    ('job', 'drydock-mysql-job'),
+    ('job', 'drydock-notes-job-mysql'),
+    ('job', 'drydock-mongodb-job'),
+    ('job', 'drydock-minio-job'),
+    ('job', 'drydock-mfe-lms-job'),
+    ('job', 'drydock-lms-job'),
+    ('job', 'drydock-forum-job'),
+    ('job', 'drydock-cms-job'),
+
+    ('deployment', 'lms'),
+    ('deployment', 'cms'),
+    ('deployment', 'lms-worker'),
+    ('deployment', 'cms-worker'),
+    ('deployment', 'forum'),
+
+    ('deployment', 'cms-debug'),
+    ('deployment', 'lms-debug'),
+    ('ingress', 'ingress-debug'),
+
+    ('deployment', 'lms-debug'),
+    ('deployment', 'cms-debug'),
+    ('ingress', 'ingress-debug'),
+]
+
+def get_priority(kind, name):
+    """ Return the priority of a k8s object."""
+    for i, (k, n) in enumerate(PRIORITY_LIST):
+        if k == kind and n == name:
+            return i + 1
+    return len(PRIORITY_LIST)
 
 ################# Configuration
 config = {
@@ -13,6 +57,7 @@ config = {
     "defaults": {
         "VERSION": __version__,
         "INIT_JOBS": False,
+        "MIGRATE_FROM": "",
         "CMS_SSO_USER": "cms",
         "AUTO_TLS": True,
         "FLOWER": False,
@@ -42,6 +87,22 @@ config = {
     },
 }
 
+def get_migration_list():
+    """
+    Return a list of migration jobs to run based on the MIGRATE_FROM and VERSION
+    settings.
+    """
+    migration_list = []
+    migrate_from = config["defaults"]["MIGRATE_FROM"]
+    migrate_to = config['defaults']['VERSION'].split('.', maxsplit=1)[0]
+    for name, version in VERSION_LIST:
+        if migrate_from.lower() == name.lower():
+            migrate_from = version
+        if migrate_from <= version <= migrate_to:
+            migration_list.append(name.lower())
+    return migration_list
+
+
 hooks.Filters.CONFIG_DEFAULTS.add_items([("OPENEDX_DEBUG_COOKIE", "ednx_enable_debug")])
 hooks.Filters.CONFIG_OVERRIDES.add_items([
         # This values are not prefixed with DRYDOCK_
@@ -65,6 +126,14 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
         ("drydock/k8s", "plugins"),
     ],
 )
+
+hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
+    [
+        ('get_priority', get_priority),
+        ('get_migration_list', get_migration_list),
+    ]
+)
+
 # Load all patches from the "patches" folder
 for path in glob(
     os.path.join(

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -47,6 +47,7 @@ hooks.Filters.CONFIG_OVERRIDES.add_items([
         # This values are not prefixed with DRYDOCK_
         ("MONGODB_ROOT_USERNAME", ""),
         ("MONGODB_ROOT_PASSWORD", ""),
+        ("MONGODB_AUTH_SOURCE", "{{ MONGODB_DATABASE }}"),
 ])
 
 

--- a/drydock/templates/drydock/k8s/debug/deployments.yml
+++ b/drydock/templates/drydock/k8s/debug/deployments.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cms-debug
   annotations:
-    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'cms-debug') }}
+    argocd.argoproj.io/sync-wave: "{{ get_priority('deployment', 'cms-debug') }}"
 spec:
   selector:
     matchLabels:
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: lms-debug
   annotations:
-    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'lms-debug') }}
+    argocd.argoproj.io/sync-wave: "{{ get_priority('deployment', 'lms-debug') }}"
 spec:
   selector:
     matchLabels:

--- a/drydock/templates/drydock/k8s/debug/deployments.yml
+++ b/drydock/templates/drydock/k8s/debug/deployments.yml
@@ -5,6 +5,8 @@ metadata:
   name: cms-debug
   labels:
     app.kubernetes.io/name: cms-debug
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'cms-debug') }}
 spec:
   selector:
     matchLabels:
@@ -57,6 +59,8 @@ metadata:
   name: lms-debug
   labels:
     app.kubernetes.io/name: lms-debug
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'lms-debug') }}
 spec:
   selector:
     matchLabels:

--- a/drydock/templates/drydock/k8s/debug/ingress.yml
+++ b/drydock/templates/drydock/k8s/debug/ingress.yml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-by-cookie: {{ OPENEDX_DEBUG_COOKIE }}
-    argocd.argoproj.io/sync-wave: {{ get_priority('ingress', 'ingress-debug') }}
+    argocd.argoproj.io/sync-wave: "{{ get_priority('ingress', 'ingress-debug') }}"
     {%- if DRYDOCK_AUTO_TLS and not DRYDOCK_CUSTOM_CERTS%}
     cert-manager.io/issuer: letsencrypt
     {%- endif %}

--- a/drydock/templates/drydock/k8s/debug/ingress.yml
+++ b/drydock/templates/drydock/k8s/debug/ingress.yml
@@ -7,6 +7,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-by-cookie: {{ OPENEDX_DEBUG_COOKIE }}
+    argocd.argoproj.io/sync-wave: {{ get_priority('ingress', 'ingress-debug') }}
     {%- if DRYDOCK_AUTO_TLS and not DRYDOCK_CUSTOM_CERTS%}
     cert-manager.io/issuer: letsencrypt
     {%- endif %}

--- a/drydock/templates/drydock/k8s/drydock-jobs/forum.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/forum.yml
@@ -30,7 +30,7 @@ spec:
           - name: SEARCH_SERVER
             value: "{{ ELASTICSEARCH_SCHEME }}://{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}"
           - name: MONGODB_AUTH
-            value: "{% if MONGODB_USERNAME and MONGODB_PASSWORD %}{{ MONGODB_USERNAME}}:{{ MONGODB_PASSWORD }}@{% endif %}"
+            value: "{% if FORUM_USERNAME is defined and FORUM_PASSWORD is defined %}{{ FORUM_USERNAME}}:{{ FORUM_PASSWORD }}@{% elif MONGODB_USERNAME and MONGODB_PASSWORD %}{{ MONGODB_USERNAME}}:{{ MONGODB_PASSWORD }}@{% endif %}"
           - name: MONGODB_HOST
             value: "{{ MONGODB_HOST }}"
           - name: MONGODB_PORT
@@ -40,7 +40,7 @@ spec:
           - name: MONGOID_USE_SSL
             value: "{{ 'true' if MONGODB_USE_SSL else 'false' }}"
           - name: MONGOID_AUTH_SOURCE
-            value: "{{ MONGODB_AUTH_SOURCE }}"
+            value: "{% if FORUM_MONGODB_DATABASE %}{{ FORUM_MONGODB_DATABASE }}{% else %}{{ MONGODB_AUTH_SOURCE }}{% endif %}"
           - name: MONGOID_AUTH_MECH
             value: "{{ MONGODB_AUTH_MECHANISM|auth_mech_as_ruby }}"
 {%- endif %}

--- a/drydock/templates/drydock/k8s/drydock-jobs/forum.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/forum.yml
@@ -8,7 +8,7 @@ metadata:
     drydock.io/target-service: forum
     drydock.io/runner-service: forum
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-forum-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/lms.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/lms.yml
@@ -7,7 +7,7 @@ metadata:
     drydock.io/target-service: lms
     drydock.io/runner-service: lms
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-lms-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/mfe.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mfe.yml
@@ -1,0 +1,93 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: drydock-mfe-lms-job
+  labels:
+    drydock.io/component: job
+    drydock.io/target-service: lms
+    drydock.io/runner-service: lms
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: lms
+        image: {{ DOCKER_IMAGE_OPENEDX }}
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          {% if MFE_ACCOUNT_MFE_APP is defined %}
+          (./manage.py lms waffle_flag --list | grep account.redirect_to_microfrontend) || ./manage.py lms waffle_flag --create --everyone account.redirect_to_microfrontend
+          ./manage.py lms populate_retirement_states
+          {% else %}
+          ./manage.py lms waffle_delete --flags account.redirect_to_microfrontend
+          {% endif %}
+
+          {% if MFE_PROFILE_MFE_APP is defined %}
+          (./manage.py lms waffle_flag --list | grep learner_profile.redirect_to_microfrontend) || ./manage.py lms waffle_flag --create --everyone learner_profile.redirect_to_microfrontend
+          site-configuration set --domain={{ LMS_HOST }} ENABLE_PROFILE_MICROFRONTEND true
+          site-configuration set --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTEND true
+          {% else %}
+          site-configuration unset --domain={{ LMS_HOST }} ENABLE_PROFILE_MICROFRONTEND
+          site-configuration unset --domain={{ LMS_HOST }}:8000 ENABLE_PROFILE_MICROFRONTEND
+          ./manage.py lms waffle_delete --flags learner_profile.redirect_to_microfrontend
+          {% endif %}
+
+          {% if MFE_LEARNING_MFE_APP is defined %}
+          (./manage.py lms waffle_flag --list | grep course_home.course_home_mfe_progress_tab) || ./manage.py lms waffle_flag --create --everyone course_home.course_home_mfe_progress_tab
+          {% else %}
+          ./manage.py lms waffle_delete --flags course_home.course_home_mfe_progress_tab
+          {% endif %}
+
+          {% if MFE_COURSE_AUTHORING_MFE_APP is defined %}
+          (./manage.py lms waffle_flag --list | grep discussions.pages_and_resources_mfe) || ./manage.py lms waffle_flag --create --everyone discussions.pages_and_resources_mfe
+          (./manage.py lms waffle_flag --list | grep new_core_editors.use_new_text_editor) || ./manage.py lms waffle_flag --create --deactivate new_core_editors.use_new_text_editor
+          (./manage.py lms waffle_flag --list | grep new_core_editors.use_new_video_editor) || ./manage.py lms waffle_flag --create --deactivate new_core_editors.use_new_video_editor
+          (./manage.py lms waffle_flag --list | grep new_core_editors.use_new_problem_editor) || ./manage.py lms waffle_flag --create --deactivate new_core_editors.use_new_problem_editor
+          {% else %}
+          ./manage.py lms waffle_delete --flags discussions.pages_and_resources_mfe
+          ./manage.py lms waffle_delete --flags new_core_editors.use_new_text_editor
+          ./manage.py lms waffle_delete --flags new_core_editors.use_new_video_editor
+          ./manage.py lms waffle_delete --flags new_core_editors.use_new_problem_editor
+          {% endif %}
+
+          {% if MFE_DISCUSSIONS_MFE_APP is defined %}
+          (./manage.py lms waffle_flag --list | grep discussions.enable_discussions_mfe ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_discussions_mfe
+          (./manage.py lms waffle_flag --list | grep discussions.enable_learners_tab_in_discussions_mfe ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_tab_in_discussions_mfe
+          (./manage.py lms waffle_flag --list | grep discussions.enable_moderation_reason_codes ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_moderation_reason_codes
+          (./manage.py lms waffle_flag --list | grep discussions.enable_reported_content_email_notifications ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_reported_content_email_notifications
+          (./manage.py lms waffle_flag --list | grep discussions.enable_learners_stats ) || ./manage.py lms waffle_flag --create --everyone discussions.enable_learners_stats
+          {% else %}
+          ./manage.py lms waffle_delete --flags discussions.enable_discussions_mfe
+          ./manage.py lms waffle_delete --flags discussions.enable_learners_tab_in_discussions_mfe
+          ./manage.py lms waffle_delete --flags discussions.enable_moderation_reason_codes
+          ./manage.py lms waffle_delete --flags discussions.enable_reported_content_email_notifications
+          ./manage.py lms waffle_delete --flags discussions.enable_learners_stats
+          {% endif %}
+        env:
+        - name: SERVICE_VARIANT
+          value: lms
+        - name: DJANGO_SETTINGS_MODULE
+          value: lms.envs.tutor.production
+        volumeMounts:
+          - mountPath: /openedx/edx-platform/lms/envs/tutor/
+            name: settings-lms
+          - mountPath: /openedx/edx-platform/cms/envs/tutor/
+            name: settings-cms
+          - mountPath: /openedx/config
+            name: config
+      volumes:
+      - name: settings-lms
+        configMap:
+          name: openedx-settings-lms
+      - name: settings-cms
+        configMap:
+          name: openedx-settings-cms
+      - name: config
+        configMap:
+          name: openedx-config

--- a/drydock/templates/drydock/k8s/drydock-jobs/mfe.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mfe.yml
@@ -7,7 +7,7 @@ metadata:
     drydock.io/target-service: lms
     drydock.io/runner-service: lms
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-mfe-lms-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/minio.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/minio.yml
@@ -8,7 +8,7 @@ metadata:
     drydock.io/target-service: minio
     drydock.io/runner-service: minio
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-minio-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/mongodb.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mongodb.yml
@@ -8,7 +8,7 @@ metadata:
     drydock.io/target-service: mongodb
     drydock.io/runner-service: mongodb
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-mongodb-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/mysql.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mysql.yml
@@ -7,7 +7,7 @@ metadata:
     drydock.io/target-service: mysql
     drydock.io/runner-service: mysql
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-mysql-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
@@ -8,7 +8,7 @@ metadata:
     drydock.io/target-service: notes
     drydock.io/runner-service: mysql
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-notes-job-mysql') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
@@ -36,7 +36,7 @@ metadata:
     drydock.io/target-service: notes
     drydock.io/runner-service: notes
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-notes-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
@@ -70,7 +70,7 @@ metadata:
     drydock.io/target-service: notes
     drydock.io/runner-service: lms
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-notes-job-lms') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:

--- a/drydock/templates/drydock/k8s/migration-jobs/maple/cms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/maple/cms.yml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: drydock-cms-job
+  name: migration-maple-cms-job
   labels:
     drydock.io/component: job
     drydock.io/target-service: cms
     drydock.io/runner-service: cms
   annotations:
-    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-cms-job') }}"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'migration-maple-cms-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
@@ -21,20 +21,11 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - |
-          dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
-
-          echo "Loading settings $DJANGO_SETTINGS_MODULE"
-
-          ./manage.py cms migrate
-
-          # Fix incorrect uploaded file path
-          if [ -d /openedx/data/uploads/ ]; then
-            if [ -n "$(ls -A /openedx/data/uploads/)" ]; then
-              echo "Migrating CMS uploaded files to shared directory"
-              mv /openedx/data/uploads/* /openedx/media/
-              rm -rf /openedx/data/uploads/
-            fi
-          fi
+          ./manage.py cms migrate contentstore
+          ./manage.py cms migrate split_modulestore_django
+          ./manage.py cms migrate backfill_course_tabs
+          ./manage.py cms migrate course_overviews
+          ./manage.py cms simulate_publish
         env:
         - name: SERVICE_VARIANT
           value: cms

--- a/drydock/templates/drydock/k8s/migration-jobs/maple/cms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/maple/cms.yml
@@ -18,13 +18,16 @@ spec:
       containers:
       - name: cms
         image: {{ DOCKER_IMAGE_OPENEDX }}
-        command: ["/bin/sh", "-c"]
+        command:
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           ./manage.py cms migrate contentstore
           ./manage.py cms migrate split_modulestore_django
-          ./manage.py cms migrate backfill_course_tabs
           ./manage.py cms migrate course_overviews
+          ./manage.py cms backfill_course_tabs
           ./manage.py cms simulate_publish
         env:
         - name: SERVICE_VARIANT

--- a/drydock/templates/drydock/k8s/migration-jobs/maple/lms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/maple/lms.yml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: drydock-cms-job
+  name: migration-maple-lms-job
   labels:
     drydock.io/component: job
-    drydock.io/target-service: cms
-    drydock.io/runner-service: cms
+    drydock.io/target-service: lms
+    drydock.io/runner-service: lms
   annotations:
-    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-cms-job') }}"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'migration-maple-lms-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
@@ -16,30 +16,18 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: cms
+      - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
         command: ["/bin/sh", "-c"]
         args:
         - |
-          dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
-
-          echo "Loading settings $DJANGO_SETTINGS_MODULE"
-
-          ./manage.py cms migrate
-
-          # Fix incorrect uploaded file path
-          if [ -d /openedx/data/uploads/ ]; then
-            if [ -n "$(ls -A /openedx/data/uploads/)" ]; then
-              echo "Migrating CMS uploaded files to shared directory"
-              mv /openedx/data/uploads/* /openedx/media/
-              rm -rf /openedx/data/uploads/
-            fi
-          fi
+          ./manage.py lms migrate user_tours
+          ./manage.py lms migrate backpopulate_user_tours
         env:
         - name: SERVICE_VARIANT
-          value: cms
+          value: lms
         - name: DJANGO_SETTINGS_MODULE
-          value: cms.envs.tutor.production
+          value: lms.envs.tutor.production
         volumeMounts:
           - mountPath: /openedx/edx-platform/lms/envs/tutor/
             name: settings-lms

--- a/drydock/templates/drydock/k8s/migration-jobs/maple/lms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/maple/lms.yml
@@ -18,11 +18,14 @@ spec:
       containers:
       - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
-        command: ["/bin/sh", "-c"]
+        command:
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           ./manage.py lms migrate user_tours
-          ./manage.py lms migrate backpopulate_user_tours
+          ./manage.py lms backpopulate_user_tours
         env:
         - name: SERVICE_VARIANT
           value: lms

--- a/drydock/templates/drydock/k8s/migration-jobs/nutmeg/lms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/nutmeg/lms.yml
@@ -18,7 +18,10 @@ spec:
       containers:
       - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
-        command: ["/bin/sh", "-c"]
+        command:
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           ./manage.py lms compute_grades -v1 --all_courses

--- a/drydock/templates/drydock/k8s/migration-jobs/nutmeg/lms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/nutmeg/lms.yml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: drydock-cms-job
+  name: migration-nutmeg-lms-job
   labels:
     drydock.io/component: job
-    drydock.io/target-service: cms
-    drydock.io/runner-service: cms
+    drydock.io/target-service: lms
+    drydock.io/runner-service: lms
   annotations:
-    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-cms-job') }}"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'migration-nutmeg-lms-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
@@ -16,30 +16,17 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: cms
+      - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
         command: ["/bin/sh", "-c"]
         args:
         - |
-          dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
-
-          echo "Loading settings $DJANGO_SETTINGS_MODULE"
-
-          ./manage.py cms migrate
-
-          # Fix incorrect uploaded file path
-          if [ -d /openedx/data/uploads/ ]; then
-            if [ -n "$(ls -A /openedx/data/uploads/)" ]; then
-              echo "Migrating CMS uploaded files to shared directory"
-              mv /openedx/data/uploads/* /openedx/media/
-              rm -rf /openedx/data/uploads/
-            fi
-          fi
+          ./manage.py lms compute_grades -v1 --all_courses
         env:
         - name: SERVICE_VARIANT
-          value: cms
+          value: lms
         - name: DJANGO_SETTINGS_MODULE
-          value: cms.envs.tutor.production
+          value: lms.envs.tutor.production
         volumeMounts:
           - mountPath: /openedx/edx-platform/lms/envs/tutor/
             name: settings-lms

--- a/drydock/templates/drydock/k8s/migration-jobs/olive/lms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/olive/lms.yml
@@ -18,7 +18,10 @@ spec:
       containers:
       - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
-        command: ["/bin/sh", "-c"]
+        command:
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           if stat '/openedx/data/ora2/SET-ME-PLEASE (ex. bucket-name)' 2> /dev/null; then

--- a/drydock/templates/drydock/k8s/migration-jobs/olive/lms.yml
+++ b/drydock/templates/drydock/k8s/migration-jobs/olive/lms.yml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: drydock-cms-job
+  name: migration-olive-lms-job
   labels:
     drydock.io/component: job
-    drydock.io/target-service: cms
-    drydock.io/runner-service: cms
+    drydock.io/target-service: lms
+    drydock.io/runner-service: lms
   annotations:
-    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'drydock-cms-job') }}"
+    argocd.argoproj.io/sync-wave: "{{ get_priority('job', 'migration-olive-lms-job') }}"
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
@@ -16,30 +16,20 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: cms
+      - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
         command: ["/bin/sh", "-c"]
         args:
         - |
-          dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
-
-          echo "Loading settings $DJANGO_SETTINGS_MODULE"
-
-          ./manage.py cms migrate
-
-          # Fix incorrect uploaded file path
-          if [ -d /openedx/data/uploads/ ]; then
-            if [ -n "$(ls -A /openedx/data/uploads/)" ]; then
-              echo "Migrating CMS uploaded files to shared directory"
-              mv /openedx/data/uploads/* /openedx/media/
-              rm -rf /openedx/data/uploads/
-            fi
+          if stat '/openedx/data/ora2/SET-ME-PLEASE (ex. bucket-name)' 2> /dev/null; then
+              echo "Renaming ora2 folder..."
+              mv '/openedx/data/ora2/SET-ME-PLEASE (ex. bucket-name)' /openedx/data/ora2/openedxuploads
           fi
         env:
         - name: SERVICE_VARIANT
-          value: cms
+          value: lms
         - name: DJANGO_SETTINGS_MODULE
-          value: cms.envs.tutor.production
+          value: lms.envs.tutor.production
         volumeMounts:
           - mountPath: /openedx/edx-platform/lms/envs/tutor/
             name: settings-lms

--- a/drydock/templates/drydock/k8s/patches/forum.yml
+++ b/drydock/templates/drydock/k8s/patches/forum.yml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forum
+spec:
+  template:
+    spec:
+      containers:
+        - name: forum
+          env:
+            - name: MONGODB_AUTH
+              value: "{% if FORUM_USERNAME is defined %}{{ FORUM_USERNAME }}:{{ FORUM_PASSWORD }}@{% elif MONGODB_USERNAME and MONGODB_PASSWORD %}{{ MONGODB_USERNAME}}:{{ MONGODB_PASSWORD }}@{% endif %}"
+            - name: MONGOID_AUTH_SOURCE
+              value: "{% if FORUM_MONGODB_DATABASE %}{{ FORUM_MONGODB_DATABASE }}{% else %}{{ MONGODB_AUTH_SOURCE }}{% endif %}"

--- a/drydock/templates/drydock/k8s/patches/sync-wave-100.yml
+++ b/drydock/templates/drydock/k8s/patches/sync-wave-100.yml
@@ -3,4 +3,4 @@ kind: not-used
 metadata:
   name: not-used
   annotations:
-    argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-wave: "100"

--- a/drydock/templates/drydock/k8s/patches/sync-wave-4.yml
+++ b/drydock/templates/drydock/k8s/patches/sync-wave-4.yml
@@ -1,6 +1,0 @@
-apiVersion: not-used
-kind: not-used
-metadata:
-  name: not-used
-  annotations:
-    argocd.argoproj.io/sync-wave: "4"

--- a/drydock/templates/drydock/k8s/sync-waves/cms-worker.yml
+++ b/drydock/templates/drydock/k8s/sync-waves/cms-worker.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cms-worker
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'cms-worker') }}

--- a/drydock/templates/drydock/k8s/sync-waves/cms.yml
+++ b/drydock/templates/drydock/k8s/sync-waves/cms.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cms
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'cms') }}

--- a/drydock/templates/drydock/k8s/sync-waves/forum.yml
+++ b/drydock/templates/drydock/k8s/sync-waves/forum.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forum
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'forum') }}

--- a/drydock/templates/drydock/k8s/sync-waves/lms-worker.yml
+++ b/drydock/templates/drydock/k8s/sync-waves/lms-worker.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lms-worker
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'lms-worker') }}

--- a/drydock/templates/drydock/k8s/sync-waves/lms.yml
+++ b/drydock/templates/drydock/k8s/sync-waves/lms.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lms
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ get_priority('deployment', 'lms') }}


### PR DESCRIPTION
# Description

This PR pretends to adds some features to Drydock.

- Support for `FORUM_PASSWORD`, `FORUM_USERNAME` and `FORUM_DATABASE` config variables.
- Add `MFE` init job to our stack of declarative jobs.
- Add sync waves priorities based on a [list](https://github.com/eduNEXT/drydock/pull/73/files#diff-3f55adcae5f69336efdfd4122728303ac1d500d870dad5884a4d8ee8e40f22ceR17).
- add `DRYDOCK_MIGRATE_FROM` variable which you could specify maple or upper. 

## How migration works

You should define `DRYDOCK_MIGRATE_FROM` as one version of the [VERSION_LIST](https://github.com/eduNEXT/drydock/pull/73/files#diff-3f55adcae5f69336efdfd4122728303ac1d500d870dad5884a4d8ee8e40f22ceR9). The target version is same as the installed drydock.

Drydock makes a list of the versions between the two versions (inclusive) and add the migrations jobs needed to achieve the target one.
