### PR TITLE
fix: run the jobs scripts with '-e' to exit on error

### DIFF
--- a/drydock/templates/drydock/k8s/drydock-jobs/cms.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/cms.yml
@@ -18,7 +18,10 @@ spec:
       containers:
       - name: cms
         image: {{ DOCKER_IMAGE_OPENEDX }}
-        command: ["/bin/sh", "-c"]
+        command: 
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s

--- a/drydock/templates/drydock/k8s/drydock-jobs/lms.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/lms.yml
@@ -18,7 +18,10 @@ spec:
       containers:
       - name: lms
         image: {{ DOCKER_IMAGE_OPENEDX }}
-        command: ["/bin/sh", "-c"]
+        command: 
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s

--- a/drydock/templates/drydock/k8s/drydock-jobs/minio.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/minio.yml
@@ -19,7 +19,10 @@ spec:
       containers:
         - name: minio
           image: {{ MINIO_MC_DOCKER_IMAGE }}
-          command: ["/bin/sh", "-c"]
+          command: 
+            - /bin/sh
+            - -c
+            - -e
           args:
           - |
             mc config host add minio http://minio:9000 {{ OPENEDX_AWS_ACCESS_KEY }} {{ OPENEDX_AWS_SECRET_ACCESS_KEY }} --api s3v4

--- a/drydock/templates/drydock/k8s/drydock-jobs/mongodb.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mongodb.yml
@@ -19,7 +19,10 @@ spec:
       containers:
       - name: mongodb
         image: {{ DOCKER_IMAGE_MONGODB }}
-        command: ["/bin/sh", "-c"]
+        command: 
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           echo "Initialising MongoDB..."

--- a/drydock/templates/drydock/k8s/drydock-jobs/mysql.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/mysql.yml
@@ -18,7 +18,10 @@ spec:
       containers:
       - name: mysql
         image: {{ DOCKER_IMAGE_MYSQL }}
-        command: ["/bin/sh", "-c"]
+        command: 
+          - /bin/sh
+          - -c
+          - -e
         args:
         - |
           echo "Initialising MySQL..."

--- a/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
+++ b/drydock/templates/drydock/k8s/drydock-jobs/notes.yml
@@ -19,7 +19,10 @@ spec:
       containers:
         - name: notes
           image: {{ DOCKER_IMAGE_MYSQL }}
-          command: ["/bin/sh", "-c"]
+          command: 
+            - /bin/sh
+            - -c
+            - -e
           args:
           - |
             mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e 'CREATE DATABASE IF NOT EXISTS {{ NOTES_MYSQL_DATABASE }};'
@@ -47,7 +50,10 @@ spec:
       containers:
         - name: notes
           image: {{ NOTES_DOCKER_IMAGE }}
-          command: ["/bin/sh", "-c"]
+          command: 
+            - /bin/sh
+            - -c
+            - -e
           args: [./manage.py migrate]
           env:
             - name: DJANGO_SETTINGS_MODULE
@@ -81,7 +87,10 @@ spec:
       containers:
         - name: notes
           image: {{ DOCKER_IMAGE_OPENEDX }}
-          command: ["/bin/sh", "-c"]
+          command: 
+            - /bin/sh
+            - -c
+            - -e
           args:
           - |
             # Modify users created an incorrect email and that might clash with the newly created users


### PR DESCRIPTION
# Description

If we run scripts using `bash -c "..."` the container that is running the command will run succesfuly if the last comand return 0 as a status code, even if intermediate commands may have failed, to avoid this we add `-e` flag to fail early on any error.
