### PR TITLE
fix: add deployments to sync wave 100

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,13 +51,14 @@ The following configuration options are available:
 - `DRYDOCK_CUSTOM_CERTS`: A dictionary of custom certificates to use with cert-manager. Defaults to `{}`.
 - `DRYDOCK_NEWRELIC_LICENSE_KEY`: The New Relic license key. Defaults to `""`.
 - `DRYDOCK_DEBUG`: Whether to deploy debug resources. Defaults to `false`.
-- `DRYDOCK_ENABLE_CELERY_TUNING` : Whether to enable celery tuning. Defaults to `true`.
-- `DRYDOCK_ENABLE_MULTITENANCY` : Whether to enable multitennacy. Defaults to `true`.
-- `DRYDOCK_ENABLE_SCORM` : Whether to enable scorm. Defaults to `true`.
-- `DRYDOCK_ENABLE_SENTRY` : Whether to enable sentry. Defaults to `true`.
-- `DRYDOCK_SENTRY_DSN` : The sentry DSN. Defaults to `""`.
-- `DRYDOCK_POD_LIFECYCLE` : Whether to enable pod lifecycle. Defaults to `true`.
-- `DRYDOCK_MIGRATE_FROM`: it allows defining the version of the OpenedX platform we are migrating from. It accepts the integer value mapping the origin release, for instance, `13`(maple) or `14`(nutmeg). When this variable is set, a group of `release-specific upgrade jobs` are added to the Kubernetes manifests. These jobs are applied to the cluster in a suitable order (thanks to the GitOps implementation with ArgoCD + sync waves) to guarantee the correct behavior of the platform in the new version. This brings the `tutor k8s upgrade <https://github.com/overhangio/tutor/blob/v15.3.7/tutor/commands/k8s.py#L484>`_ command to the GitOps pattern. The release-specific upgrade jobs are supported from release `13`(maple). Defaults to `0` (which disables release-specific upgrade jobs)
+- `DRYDOCK_ENABLE_CELERY_TUNING`: Whether to enable celery tuning. Defaults to `true`.
+- `DRYDOCK_ENABLE_MULTITENANCY`: Whether to enable multitennacy. Defaults to `true`.
+- `DRYDOCK_ENABLE_SCORM`: Whether to enable scorm. Defaults to `true`.
+- `DRYDOCK_ENABLE_SENTRY`: Whether to enable sentry. Defaults to `true`.
+- `DRYDOCK_SENTRY_DSN`: The sentry DSN. Defaults to `""`.
+- `DRYDOCK_POD_LIFECYCLE`: Whether to enable pod lifecycle. Defaults to `true`.
+- `DRYDOCK_MIGRATE_FROM`: it allows defining the version of the OpenedX platform we are migrating from. It accepts the integer value mapping the origin release, for instance, `13`(maple) or `14`(nutmeg). When this variable is set, a group of `release-specific upgrade jobs` are added to the Kubernetes manifests. These jobs are applied to the cluster in a suitable order (thanks to the GitOps implementation with ArgoCD + sync waves) to guarantee the correct behavior of the platform in the new version. This brings the `tutor k8s upgrade <https://github.com/overhangio/tutor/blob/v16.1.8/tutor/commands/k8s.py#L486>`_ command to the GitOps pattern. The release-specific upgrade jobs are supported from release `13`(maple). Defaults to `0` (which disables release-specific upgrade jobs)
+- `DRYDOCK_POST_INIT_DEPLOYMENTS`: A list of Kubernetes deployments to be applied after the initialization jobs. There are specific deployments that won't report a healthy status in ArgoCD unless the initialization requirements are guaranteed (for instance, database users creation). Thanks to the ArgoCD sync waves feature, the deployments defined in this variable can be synchronized in a phase after the execution of the initialization jobs in order to prevent OpenedX environment syncing failures. In most cases this variable should not be changed. Defaults to `["lms", "cms", "lms-worker", "cms-worker", "forum"]`.
 
 .. note::
     You also need to set `DRYDOCK_INIT_JOBS` to `true` to enable the release-specific upgrade jobs in the case of a platform migration.
@@ -88,13 +89,14 @@ Workaround to upgrade from Maple to Palm
 The upgrade from Maple to Palm fails because an issue with a squashed migration in `edx-enterprise <https://github.com/openedx/edx-enterprise/blob/3.61.11/integrated_channels/blackboard/migrations/0001_initial_squashed_0014_alter_blackboardlearnerassessmentdatatransmissionaudit_enterprise_course_enrollment_id.py>`_. To go around this issue, we need to apply migrations using an older version of edx-enterprise (3.60.4).
 
 1. Run the sync to Palm without enabling the init jobs or upgrade jobs.
+
 2. Once the LMS Deployment is running in the Palm version, go inside a pod and run the following:
 
-.. code: bash
+.. code:: bash
 
-        pip install edx-enterprise==3.60.4
-        ./manage.py lms migrate
-        pip install edx-enterprise==3.61.11
+    pip install edx-enterprise==3.60.4
+    ./manage.py lms migrate
+    pip install edx-enterprise==3.61.11
 
 3. Now, you can enable the init jobs and upgrade jobs and run the sync again.
 

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -20,3 +20,7 @@ patches:
 - target:
     kind: HorizontalPodAutoscaler
   path: plugins/drydock/k8s/patches/hpa-sync-wave.yml
+- target:
+    kind: Deployment
+    name: '{% for name in DRYDOCK_POST_INIT_DEPLOYMENTS %}{{ name }}{% if not loop.last %}|{% endif %}{% endfor %}'
+  path: plugins/drydock/k8s/patches/post-init-deployments-sync-wave.yml

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -75,11 +75,10 @@ def get_init_tasks():
 CORE_SYNC_WAVES_ORDER: SYNC_WAVES_ORDER_ATTRS_TYPE = {
     "drydock-upgrade-lms-job": 50,
     "drydock-upgrade-cms-job": 51,
-    "lms-lifecycle-enabled": 100,
-    "cms-lifecycle-enabled": 100,
     "lms-debug": 50,
     "cms-debug": 50,
     "ingress-debug": 200,
+    "deployments:post-init-apps": 100,
     "horizontalpodautoscalers:all": 150
 }
 
@@ -149,6 +148,13 @@ config = {
         "SENTRY_DSN": "",
         "POD_LIFECYCLE": True,
         "BYPASS_CADDY": False,
+        "POST_INIT_DEPLOYMENTS": [
+            "lms",
+            "cms",
+            "forum",
+            "lms-worker",
+            "cms-worker",
+        ],
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -2,8 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cms
-  annotations:
-    argocd.argoproj.io/sync-wave: "{{ get_sync_waves_for_resource('cms-lifecycle-enabled') }}"
 spec:
   template:
     spec:

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -2,8 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: lms
-  annotations:
-    argocd.argoproj.io/sync-wave: "{{ get_sync_waves_for_resource('lms-lifecycle-enabled') }}"
 spec:
   template:
     spec:

--- a/drydock/templates/drydock/k8s/patches/post-init-deployments-sync-wave.yml
+++ b/drydock/templates/drydock/k8s/patches/post-init-deployments-sync-wave.yml
@@ -1,0 +1,6 @@
+apiVersion: not-used
+kind: not-used
+metadata:
+  name: not-used
+  annotations:
+    argocd.argoproj.io/sync-wave: "{{ get_sync_waves_for_resource('deployments:post-init-apps') }}"


### PR DESCRIPTION
# Descripcion

The LMS-WORKER, CMS-WORKER and FORUM deployments are failing when you need to create database users first. 

This changes are made to take the critical deployments on the sync wave 100, adding a list to allow the env to add more just in case.