### PR TITLE
fix: enable celery autoscaling

### DIFF
--- a/drydock/templates/drydock/k8s/celery/cms-worker.yml
+++ b/drydock/templates/drydock/k8s/celery/cms-worker.yml
@@ -13,7 +13,7 @@ spec:
             - --app=cms.celery
             - worker
             - --loglevel=info
-            - --concurrency=1
+            - --autoscale=10,1
             - --hostname=edx.cms.core.default.%%h
             - --max-tasks-per-child=1
             - --prefetch-multiplier=1

--- a/drydock/templates/drydock/k8s/celery/cms-worker.yml
+++ b/drydock/templates/drydock/k8s/celery/cms-worker.yml
@@ -13,8 +13,7 @@ spec:
             - --app=cms.celery
             - worker
             - --loglevel=info
-            - --autoscale=10,1
             - --hostname=edx.cms.core.default.%%h
-            - --max-tasks-per-child=1
+            - --max-tasks-per-child=100
             - --prefetch-multiplier=1
             - --exclude-queues=edx.lms.core.default

--- a/drydock/templates/drydock/k8s/celery/lms-worker.yml
+++ b/drydock/templates/drydock/k8s/celery/lms-worker.yml
@@ -13,7 +13,7 @@ spec:
             - --app=lms.celery
             - worker
             - --loglevel=info
-            - --concurrency=1
+            - --autoscale=10,1
             - --hostname=edx.lms.core.default.%%h
             - --max-tasks-per-child=1
             - --prefetch-multiplier=1

--- a/drydock/templates/drydock/k8s/celery/lms-worker.yml
+++ b/drydock/templates/drydock/k8s/celery/lms-worker.yml
@@ -15,6 +15,6 @@ spec:
             - --loglevel=info
             - --autoscale=10,1
             - --hostname=edx.lms.core.default.%%h
-            - --max-tasks-per-child=1
+            - --max-tasks-per-child=100
             - --prefetch-multiplier=1
             - --exclude-queues=edx.cms.core.default


### PR DESCRIPTION
### Description

This PR removes the [concurrency](https://docs.celeryq.dev/en/stable/userguide/workers.html#concurrency) parameter of celery in favor of [autoscale](https://docs.celeryq.dev/en/stable/userguide/workers.html#autoscaling) which provides a minimum and a maximum concurrency, allowing Celery to scale based on the workload.

A fixed number of `concurrency` is not optimal for any workload.

### Author concerns

By default, Celery uses the prefork pool which uses Python's multiprocessing package which uses only the available CPU cores so, setting the max limit of `autoscale` to 10 can be problematic. However, this would make a more efficient use of available hardware and allow any HPA resource to scale better.