### PR TITLE
fix: enable scorm proxy if s3 plugin is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following configuration options are available:
 - `DRYDOCK_FLOWER`: Whether to deploy a flower deployment for celery. Defaults to `false`.
 - `DRYDOCK_INGRESS`: Whether to deploy an ingress for the LMS and CMS. Defaults to `false`.
 - `DRYDOCK_INGRESS_EXTRA_HOSTS`: A list of extra hosts to add to the ingress. Defaults to `[]`.
+- `DRYDOCK_INGRESS_LMS_EXTRA_HOSTS`: A list of extra hosts to add to the LMS ingress. Defaults to `[]`.
 - `DRYDOCK_CUSTOM_CERTS`: A dictionary of custom certificates to use with cert-manager. Defaults to `{}`.
 - `DRYDOCK_NEWRELIC_LICENSE_KEY`: The New Relic license key. Defaults to `""`.
 - `DRYDOCK_DEBUG`: Whether to deploy debug resources. Defaults to `false`.

--- a/drydock/patches/caddyfile
+++ b/drydock/patches/caddyfile
@@ -15,7 +15,7 @@ request_body {
     max_size 4MB
 }
 import proxy "lms:8000"
-{% if DRYDOCK_ENABLE_SCORM -%}
+{% if DRYDOCK_ENABLE_SCORM and (MINIO_HOST is defined or S3_STORAGE_BUCKET is defined) -%}
 @scorm_matcher {
     path /scorm-proxy/*
 }
@@ -24,7 +24,7 @@ route @scorm_matcher {
 {% if MINIO_HOST is defined %}
     reverse_proxy minio:9000 {
         header_up Host {{ MINIO_HOST }}
-{% else %}
+{% elif S3_STORAGE_BUCKET is defined %}
     reverse_proxy https://{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com {
         header_up Host {{ S3_STORAGE_BUCKET }}.s3.amazonaws.com
 {% endif %}

--- a/drydock/patches/caddyfile-cms
+++ b/drydock/patches/caddyfile-cms
@@ -1,4 +1,4 @@
-{% if DRYDOCK_ENABLE_SCORM -%}
+{% if DRYDOCK_ENABLE_SCORM and (MINIO_HOST is defined or S3_STORAGE_BUCKET is defined) -%}
 @scorm_matcher {
     path /scorm-proxy/*
 }
@@ -7,7 +7,7 @@ route @scorm_matcher {
     uri replace /scorm-proxy/ /{{ MINIO_BUCKET_NAME }}/
     reverse_proxy minio:9000 {
     header_up Host {{ MINIO_HOST }}
-{% else %}
+{% elif S3_STORAGE_BUCKET is defined %}
     uri /scorm-proxy/* strip_prefix /scorm-proxy
     reverse_proxy https://{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com {
     header_up Host {{ S3_STORAGE_BUCKET }}.s3.amazonaws.com

--- a/drydock/patches/caddyfile-lms
+++ b/drydock/patches/caddyfile-lms
@@ -1,4 +1,4 @@
-{% if DRYDOCK_ENABLE_SCORM -%}
+{% if DRYDOCK_ENABLE_SCORM and (MINIO_HOST is defined or S3_STORAGE_BUCKET is defined) -%}
 @scorm_matcher {
     path /scorm-proxy/*
 }
@@ -7,7 +7,7 @@ route @scorm_matcher {
     uri replace /scorm-proxy/ /{{ MINIO_BUCKET_NAME }}/
     reverse_proxy minio:9000 {
     header_up Host {{ MINIO_HOST }}
-{% else %}
+{% elif S3_STORAGE_BUCKET is defined %}
     uri /scorm-proxy/* strip_prefix /scorm-proxy
     reverse_proxy https://{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com {
     header_up Host {{ S3_STORAGE_BUCKET }}.s3.amazonaws.com

--- a/drydock/templates/drydock/k8s/ingress/cms.yml
+++ b/drydock/templates/drydock/k8s/ingress/cms.yml
@@ -8,7 +8,7 @@ metadata:
     {%- if DRYDOCK_AUTO_TLS and not DRYDOCK_CUSTOM_CERTS%}
     cert-manager.io/issuer: letsencrypt
     {%- endif %}
-    {%- if DRYDOCK_ENABLE_SCORM and DRYDOCK_BYPASS_CADDY %}
+    {%- if DRYDOCK_ENABLE_SCORM and DRYDOCK_BYPASS_CADDY and S3_STORAGE_BUCKET is defined %}
     nginx.ingress.kubernetes.io/server-snippet: |
       location /scorm-proxy {
         proxy_http_version     1.1;

--- a/drydock/templates/drydock/k8s/ingress/lms.yml
+++ b/drydock/templates/drydock/k8s/ingress/lms.yml
@@ -8,7 +8,7 @@ metadata:
   {%- if DRYDOCK_AUTO_TLS and not DRYDOCK_CUSTOM_CERTS %}
     cert-manager.io/issuer: letsencrypt
   {%- endif %}
-  {%- if DRYDOCK_ENABLE_SCORM and DRYDOCK_BYPASS_CADDY %}
+  {%- if DRYDOCK_ENABLE_SCORM and DRYDOCK_BYPASS_CADDY and S3_STORAGE_BUCKET is defined %}
     nginx.ingress.kubernetes.io/server-snippet: |
       location /scorm-proxy {
         proxy_http_version     1.1;


### PR DESCRIPTION
### Description

This PR fixes an issue with the scorm functionality where it failed to render the templates because the `tutor-contrib-s3` plugin was not installed.
