### PR TITLE
fix: solve error check k8s workflow main

### DIFF
--- a/.github/workflows/kubeconform-validation.yml
+++ b/.github/workflows/kubeconform-validation.yml
@@ -44,4 +44,4 @@ jobs:
           kubeconform: latest
       - name: Check k8s manifests
         run: |
-          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version latest
+          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version master


### PR DESCRIPTION
# Description

This PR include a fix to the `Check k8s manifests` workflow to resolve the error:
```
invalid value "latest" for flag -kubernetes-version: latest is not a valid version. Valid values are "master" (default) or full version x.y.z (e.g. "1.27.2")
```