### PR TITLE
fix: solve error check k8s workflow palm

### DIFF
--- a/.github/workflows/kubeconform-validation.yml
+++ b/.github/workflows/kubeconform-validation.yml
@@ -2,6 +2,8 @@ name: Kubeconform Validation
 
 on:
   pull_request:
+  push:
+    branches: main
 
 jobs:
   load-environments:
@@ -41,7 +43,15 @@ jobs:
         with:
           kubectl: latest
           kustomize: latest
-          kubeconform: latest
+          kubeconform: v0.6.6
+      - name: Print versions
+        run: |
+          echo "Kubectl version installed:"
+          kubectl version --client
+          echo "Kustomize version installed:"
+          kustomize version
+          echo "Kubeconform version installed:"
+          kubeconform -v
       - name: Check k8s manifests
         run: |
           kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version master

--- a/.github/workflows/kubeconform-validation.yml
+++ b/.github/workflows/kubeconform-validation.yml
@@ -44,4 +44,4 @@ jobs:
           kubeconform: latest
       - name: Check k8s manifests
         run: |
-          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version latest
+          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version master

--- a/.github/workflows/kubeconform-validation.yml
+++ b/.github/workflows/kubeconform-validation.yml
@@ -52,6 +52,13 @@ jobs:
           kustomize version
           echo "Kubeconform version installed:"
           kubeconform -v
+      - name: Extract Kubernetes client version
+        id: extract_version
+        run: |
+          KUBECTL_VERSION=$(kubectl version --client --output=json | jq -r '.clientVersion.gitVersion' | sed 's/^v//')
+          echo "Extracted KUBECTL_VERSION=${KUBECTL_VERSION}"
+          echo "k8s_version=${KUBECTL_VERSION}" >> $GITHUB_OUTPUT
       - name: Check k8s manifests
         run: |
-          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version master
+          K8S_VERSION=${{ steps.extract_version.outputs.k8s_version }}
+          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version ${K8S_VERSION}

--- a/.github/workflows/kubeconform-validation.yml
+++ b/.github/workflows/kubeconform-validation.yml
@@ -3,7 +3,7 @@ name: Kubeconform Validation
 on:
   pull_request:
   push:
-    branches: main
+    branches: palm
 
 jobs:
   load-environments:


### PR DESCRIPTION
# Description

This PR include a fix to the `Check k8s manifests` workflow to resolve the error:
```
invalid value "latest" for flag -kubernetes-version: latest is not a valid version. Valid values are "master" (default) or full version x.y.z (e.g. "1.27.2")
```