### PR TITLE
feat: add support for static cache config

### DIFF
--- a/.github/environments/enabled/config.yml
+++ b/.github/environments/enabled/config.yml
@@ -30,3 +30,19 @@ DRYDOCK_PDB_MINAVAILABLE_PERCENTAGE_LMS_WORKER: 50
 DRYDOCK_PDB_MINAVAILABLE_PERCENTAGE_CMS: 50
 DRYDOCK_PDB_MINAVAILABLE_PERCENTAGE_CMS_WORKER: 50
 DRYDOCK_MIGRATE_FROM: 13
+LMS_HOST: local.edly.io
+CMS_HOST: studio.local.edly.io
+MFE_HOST: apps.local.edly.io
+NGINX_STATIC_CACHE_CONFIG:
+  lms:
+    host: "{{LMS_HOST}}"
+    path: /static/
+    port: 8000
+  cms:
+    host: "{{CMS_HOST}}"
+    path: /static/
+    port: 8000
+  mfe:
+    host: "{{MFE_HOST}}"
+    path: /
+    port: 8002

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ The following configuration options are available:
 - `DRYDOCK_ENABLE_SENTRY`: Whether to enable sentry. Defaults to `true`.
 - `DRYDOCK_SENTRY_DSN`: The sentry DSN. Defaults to `""`.
 - `DRYDOCK_POD_LIFECYCLE`: Whether to enable pod lifecycle. Defaults to `true`.
+- `NGINX_STATIC_CACHE_CONFIG`: A list of dictionaries with settings for different services to cache their assets in NGINX.
+  The following is an example of the expected values:
+  ```yaml
+  NGINX_STATIC_CACHE_CONFIG:
+    {{service_name}}:
+        host: {{service_host}} # e.g: {{LMS_HOST}}
+        path: /static/ # you can specify a different path
+        port: {{service_port}} # only needed if you have DRYDOCK_BYPASS_CADDY enabled
+  ```
 - `DRYDOCK_PDB_MINAVAILABLE_PERCENTAGE_MFE`: The minimum available percentage for the MFE's PodDisruptionBudget. To disable the PodDisruptionBudget, set `0`. Defaults to `0`.
 - `DRYDOCK_PDB_MINAVAILABLE_PERCENTAGE_FORUM`: The minimum available percentage for the FORUM's PodDisruptionBudget. To disable the PodDisruptionBudget, set `0`. Defaults to `0`.
 - `DRYDOCK_PDB_MINAVAILABLE_PERCENTAGE_CADDY`: The minimum available percentage for the CADDY's PodDisruptionBudget. To disable the PodDisruptionBudget, set `0`. Defaults to `0`.

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -12,6 +12,7 @@
 - plugins/drydock/k8s/ingress/cms.yml
 - plugins/drydock/k8s/ingress/mfe.yml
 - plugins/drydock/k8s/ingress/extra-hosts.yml
+- plugins/drydock/k8s/ingress/static-cache.yml
 {%- endif %}
 {% if DRYDOCK_DEBUG -%}
 - plugins/drydock/k8s/debug/deployments.yml

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -162,6 +162,7 @@ config = {
             "lms-worker",
             "cms-worker",
         ],
+        "NGINX_STATIC_CACHE_CONFIG": {},
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.

--- a/drydock/templates/drydock/k8s/ingress/static-cache.yml
+++ b/drydock/templates/drydock/k8s/ingress/static-cache.yml
@@ -1,0 +1,33 @@
+{%- for service, config in DRYDOCK_NGINX_STATIC_CACHE_CONFIG.items() %}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-static-{{ service }}
+  namespace: {{ K8S_NAMESPACE }}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      # Cache settings
+      proxy_cache_valid 404 10m;
+      proxy_cache_use_stale error timeout updating http_404 http_500 http_502 http_503 http_504;
+      proxy_cache static-cache;
+      proxy_cache_valid any 120m;
+      proxy_cache_bypass $http_x_purge;
+      add_header X-Cache-Status $upstream_cache_status;
+      {{ patch("static-cache-config") | indent(6)}}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ config["host"] }}
+    http:
+      paths:
+        - pathType: Prefix
+          path: {{ config["path"]}}
+          backend:
+            service:
+              name: {% if DRYDOCK_BYPASS_CADDY -%}{{ service }}{% else -%}caddy{% endif %}
+              port:
+                number: {% if DRYDOCK_BYPASS_CADDY -%}{{ config["port"] }}{% else -%}80{% endif %}
+{%- endfor %}


### PR DESCRIPTION
### Description

This PR allows the setup of a configurable static cache running on NGINX. Make sure to configure the following snippet to your nginx HTTP config:

```nginx
proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=static-cache:32m use_temp_path=off max_size=4g inactive=24h;
proxy_cache_key $scheme$proxy_host$request_uri;
proxy_cache_lock on;
proxy_cache_use_stale updating;
proxy_ignore_headers Cache-Control;
```

### Benchmarks:

Using k6 for fetching multiple static files.

Before:
```
          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: openedx-testing/mfe/request_static_files.js
        output: -

     scenarios: (100.00%) 1 scenario, 400 max VUs, 1m0s max duration (incl. graceful stop):
              * default: 400 looping VUs for 30s (gracefulStop: 30s)

     █ MFE static files

     data_received........: 413 MB 12 MB/s
     group_duration.......: avg=4.46s    min=2.07s    med=4.12s    max=9.52s p(90)=6.37s p(95)=7.88s
     http_req_duration....: avg=2.11s    min=192.17ms med=1.99s    max=6.37s p(90)=3.38s p(95)=3.95s
     http_req_failed......: 0.00%  ✓ 0          ✗ 4704 
     http_req_receiving...: avg=696.22ms min=71.23µs  med=154.75ms max=3.97s p(90)=1.85s p(95)=2.26s
     http_req_waiting.....: avg=1.41s    min=158.02ms med=1.31s    max=4.88s p(90)=2.31s p(95)=2.73s
     http_reqs............: 4704   132.536314/s
     vus..................: 3      min=3        max=400
```
After:
```
          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: openedx-testing/mfe/request_static_files.js
        output: -

     scenarios: (100.00%) 1 scenario, 400 max VUs, 1m0s max duration (incl. graceful stop):
              * default: 400 looping VUs for 30s (gracefulStop: 30s)

     █ MFE static files

     data_received........: 768 MB 22 MB/s
     group_duration.......: avg=1.88s    min=285.36ms med=1.45s    max=12.83s p(90)=4.22s    p(95)=5.14s   
     http_req_duration....: avg=864.04ms min=133.68ms med=333.14ms max=9.8s   p(90)=2.2s     p(95)=3s      
     http_req_failed......: 0.00%  ✓ 0          ✗ 8756 
     http_req_receiving...: avg=617.4ms  min=94.65µs  med=5.2ms    max=8.47s  p(90)=1.92s    p(95)=2.65s   
     http_req_waiting.....: avg=246.54ms min=132.95ms med=154.04ms max=3.15s  p(90)=510.83ms p(95)=768.91ms
     http_reqs............: 8756   253.325541/s
     vus..................: 7      min=7        max=400
```

