### PR TITLE
fix: replace deprecated bucket argument for recommended bucket_name

### DIFF
--- a/drydock/patches/openedx-common-settings
+++ b/drydock/patches/openedx-common-settings
@@ -8,7 +8,7 @@ def scorm_xblock_storage(xblock):
     else:
         domain = settings.CMS_BASE
     return S3Boto3Storage(
-        bucket=AWS_STORAGE_BUCKET_NAME,
+        bucket_name=AWS_STORAGE_BUCKET_NAME,
         access_key=AWS_ACCESS_KEY_ID,
         secret_key=AWS_SECRET_ACCESS_KEY,
         querystring_expire=86400,


### PR DESCRIPTION
### Description

The S3Boto3Storage backend no longer accepts the argument bucket. Use bucket_name or the setting AWS_STORAGE_BUCKET_NAME instead: https://github.com/jschneier/django-storages/pull/636

This PR fixes this error in quince installations using django-storages 1.14:
```
  File "/openedx/edx-platform/./lms/envs/tutor/production.py", line 255, in scorm_xblock_storage
    return S3Boto3Storage(
  File "/openedx/venv/lib/python3.8/site-packages/storages/backends/s3.py", line 280, in __init__
    super().__init__(**settings)
  File "/openedx/venv/lib/python3.8/site-packages/storages/base.py", line 15, in __init__
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Invalid setting 'bucket' for S3Storage
```