### PR TITLE
ci: ignore commits in changelog and release notes - olive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "tutor>=17.0.2,<18.0.0"
+    "tutor>=15.0.0,<16.0.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,12 @@ match = "olive"
 
 [tool.semantic_release.changelog.environment]
 keep_trailing_newline = true
+
+[tool.semantic_release.changelog]
+exclude_commit_patterns = [
+  "docs:",
+  "build:",
+  "style:",
+  "chore:",
+  "test:",
+]


### PR DESCRIPTION
# Description

This PR ignores the following commit mesagges to be included in the changelog and release notes

  docs
  build
  style
  chore
  test