### PR TITLE
ci: ignore commits in changelog and release notes - palm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,12 @@ match = "palm"
 
 [tool.semantic_release.changelog.environment]
 keep_trailing_newline = true
+
+[tool.semantic_release.changelog]
+exclude_commit_patterns = [
+  "docs:",
+  "build:",
+  "style:",
+  "chore:",
+  "test:",
+]


### PR DESCRIPTION
# Description

This PR ignores the following commit mesagges to be included in the changelog and release notes

docs
build
style
chore
test