### PR TITLE
Redwood

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Extra plugins added:
 - A patch that allows for the use of sentry via `DRYDOCK_ENABLE_SENTRY` and `DRYDOCK_SENTRY_DSN`
 - Patch for cms and lms worker pods to allow pod probes and lifecycle to work properly. Enabled via `DRYDOCK_POD_LIFECYCLE`
 
+Version compatibility matrix
+----------------------------
+
+You must install a supported release of this plugin to match the Open
+edX and Tutor version you are deploying. If you are installing this
+plugin from a branch in this Git repository, you must select the
+appropriate one:
+
+| Open edX release | Tutor version     | Plugin branch | Plugin release |
+|------------------|-------------------|---------------|----------------|
+| Maple            | `>=13.2, <14`     | Not supported | 0.7.x          |
+| Nutmeg           | `>=14.0, <15`     | Not supported | 0.7.x          |
+| Olive            | `>=15.0, <16`     | Not supported | 15.x.x         |
+| Palm             | `>=16.0, <17`     | `palm`        | 16.x.x         |
+| Quince           | `>=17.0, <18`     | `quince`      | 17.x.x         |
+| Redwood          | `>=18.0, <19`     | `main`        | >=18.0.0       |
+
 Installation
 ------------
 

--- a/drydock/templates/drydock/task/mongodb/init
+++ b/drydock/templates/drydock/task/mongodb/init
@@ -1,5 +1,5 @@
 echo "Initialising MongoDB..."
-mongo --host {{MONGODB_HOST }} {% if MONGODB_ROOT_USERNAME and MONGODB_ROOT_PASSWORD %} -u {{ MONGODB_ROOT_USERNAME }} -p {{ MONGODB_ROOT_PASSWORD }} {% endif %} admin <<EOF
+mongosh --host {{MONGODB_HOST }} {% if MONGODB_ROOT_USERNAME and MONGODB_ROOT_PASSWORD %} -u {{ MONGODB_ROOT_USERNAME }} -p {{ MONGODB_ROOT_PASSWORD }} {% endif %} admin <<EOF
   {% if MONGODB_USERNAME %}
   if (db.getUser("{{ MONGODB_USERNAME }}") == null) {
     db.createUser({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "tutor>=17.0.2,<18.0.0"
+    "tutor>=18.0.0,<19.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

This PR adds support to Redwood release

Currently working on: https://argocd.services.stage.edunext-shipyard.net/applications/argocd/musashi.chennai.redwood-stage?view=tree&resource=

And a migrations made from quince: https://argocd.services.stage.edunext-shipyard.net/applications/argocd/musashi.tunis.quinoa-prod?view=tree&resource=