### PR TITLE
fix: remove unnecesary annotations from the hpa sync wave

### DIFF
--- a/drydock/templates/drydock/k8s/patches/hpa-sync-wave.yml
+++ b/drydock/templates/drydock/k8s/patches/hpa-sync-wave.yml
@@ -4,5 +4,3 @@ metadata:
   name: not-used
   annotations:
     argocd.argoproj.io/sync-wave: "{{ get_sync_waves_for_resource('horizontalpodautoscalers:all') }}"
-    argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded


### PR DESCRIPTION
# Description
The HPA sync-wave patch includes annotations to indicate argocd in which order should the HPA resources be applied in relation to the other resources. The `argocd.argoproj.io/hook: Sync` and `argocd.argoproj.io/hook-delete-policy: HookSucceeded` annotations are used for ephemeral resources (like jobs) and should not be used for the HPA resources.

# Testing

Install https://github.com/eduNEXT/tutor-contrib-pod-autoscaling and activate the HPAs. The resources should be missing in the ArgoCD UI. Apply the fix and they should appear again.