### PR TITLE
fix: remove unnecesary annotations from the hpa sync wave (quince)

### DIFF
--- a/drydock/templates/drydock/k8s/patches/hpa-sync-wave.yml
+++ b/drydock/templates/drydock/k8s/patches/hpa-sync-wave.yml
@@ -4,5 +4,3 @@ metadata:
   name: not-used
   annotations:
     argocd.argoproj.io/sync-wave: "{{ get_sync_waves_for_resource('horizontalpodautoscalers:all') }}"
-    argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded


### PR DESCRIPTION
Backport of https://github.com/eduNEXT/drydock/pull/117