### PR TITLE
fix: S3_HOST for alternative S3-compatible services

### DIFF
--- a/drydock/patches/caddyfile
+++ b/drydock/patches/caddyfile
@@ -32,8 +32,8 @@
     }
     route @scorm_matcher {
         uri /scorm-proxy/* strip_prefix /scorm-proxy
-        reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }} {
-            header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}
+        reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }} {
+            header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}
         }
     }
     {% endif %}

--- a/drydock/patches/caddyfile
+++ b/drydock/patches/caddyfile
@@ -32,8 +32,8 @@
     }
     route @scorm_matcher {
         uri /scorm-proxy/* strip_prefix /scorm-proxy
-        reverse_proxy https://{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com {
-            header_up Host {{ S3_STORAGE_BUCKET }}.s3.amazonaws.com
+        reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }} {
+            header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}
         }
     }
     {% endif %}

--- a/drydock/patches/caddyfile-cms
+++ b/drydock/patches/caddyfile-cms
@@ -14,8 +14,8 @@ route @scorm_matcher {
 }
 route @scorm_matcher {
     uri /scorm-proxy/* strip_prefix /scorm-proxy
-    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com {
-        header_up Host {{ S3_STORAGE_BUCKET }}.s3.amazonaws.com
+    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }} {
+        header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}
     }
 }
 {% endif %}

--- a/drydock/patches/caddyfile-cms
+++ b/drydock/patches/caddyfile-cms
@@ -14,8 +14,8 @@ route @scorm_matcher {
 }
 route @scorm_matcher {
     uri /scorm-proxy/* strip_prefix /scorm-proxy
-    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }} {
-        header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}
+    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }} {
+        header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}
     }
 }
 {% endif %}

--- a/drydock/patches/caddyfile-lms
+++ b/drydock/patches/caddyfile-lms
@@ -14,8 +14,8 @@ route @scorm_matcher {
 }
 route @scorm_matcher {
     uri /scorm-proxy/* strip_prefix /scorm-proxy
-    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com {
-        header_up Host {{ S3_STORAGE_BUCKET }}.s3.amazonaws.com
+    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }} {
+        header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}
     }
 }
 {% endif %}

--- a/drydock/patches/caddyfile-lms
+++ b/drydock/patches/caddyfile-lms
@@ -14,8 +14,8 @@ route @scorm_matcher {
 }
 route @scorm_matcher {
     uri /scorm-proxy/* strip_prefix /scorm-proxy
-    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }} {
-        header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}
+    reverse_proxy https://{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }} {
+        header_up Host {{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}
     }
 }
 {% endif %}

--- a/drydock/templates/drydock/k8s/ingress/cms.yml
+++ b/drydock/templates/drydock/k8s/ingress/cms.yml
@@ -14,7 +14,7 @@ metadata:
         proxy_http_version     1.1;
         proxy_set_header       Connection "";
         proxy_set_header       Authorization '';
-        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com{%- endif %};
+        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
         proxy_hide_header      x-amz-id-2;
         proxy_hide_header      x-amz-request-id;
         proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -24,7 +24,7 @@ metadata:
         proxy_intercept_errors on;
         add_header             Cache-Control max-age=31536000;
         rewrite /scorm-proxy(.*) $1 break;
-        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com{%- endif %};
+        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
       }
   {%- endif %}
 spec:

--- a/drydock/templates/drydock/k8s/ingress/cms.yml
+++ b/drydock/templates/drydock/k8s/ingress/cms.yml
@@ -14,7 +14,7 @@ metadata:
         proxy_http_version     1.1;
         proxy_set_header       Connection "";
         proxy_set_header       Authorization '';
-        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
+        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}{%- endif %};
         proxy_hide_header      x-amz-id-2;
         proxy_hide_header      x-amz-request-id;
         proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -24,7 +24,7 @@ metadata:
         proxy_intercept_errors on;
         add_header             Cache-Control max-age=31536000;
         rewrite /scorm-proxy(.*) $1 break;
-        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
+        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}{%- endif %};
       }
   {%- endif %}
 spec:

--- a/drydock/templates/drydock/k8s/ingress/lms.yml
+++ b/drydock/templates/drydock/k8s/ingress/lms.yml
@@ -14,7 +14,7 @@ metadata:
         proxy_http_version     1.1;
         proxy_set_header       Connection "";
         proxy_set_header       Authorization '';
-        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com{%- endif %};
+        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
         proxy_hide_header      x-amz-id-2;
         proxy_hide_header      x-amz-request-id;
         proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -24,7 +24,7 @@ metadata:
         proxy_intercept_errors on;
         add_header             Cache-Control max-age=31536000;
         rewrite /scorm-proxy(.*) $1 break;
-        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com{%- endif %};
+        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
       }
   {%- endif %}
 spec:

--- a/drydock/templates/drydock/k8s/ingress/lms.yml
+++ b/drydock/templates/drydock/k8s/ingress/lms.yml
@@ -14,7 +14,7 @@ metadata:
         proxy_http_version     1.1;
         proxy_set_header       Connection "";
         proxy_set_header       Authorization '';
-        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
+        proxy_set_header       Host {% if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}{%- endif %};
         proxy_hide_header      x-amz-id-2;
         proxy_hide_header      x-amz-request-id;
         proxy_hide_header      x-amz-meta-server-side-encryption;
@@ -24,7 +24,7 @@ metadata:
         proxy_intercept_errors on;
         add_header             Cache-Control max-age=31536000;
         rewrite /scorm-proxy(.*) $1 break;
-        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}{%- endif %};
+        proxy_pass https://{%- if MINIO_HOST is defined %}{{ MINIO_HOST }}{% else %}{{ S3_STORAGE_BUCKET }}.{{ S3_HOST or 's3.amazonaws.com' }}{%- endif %};
       }
   {%- endif %}
 spec:


### PR DESCRIPTION
When enabling SCORM features, a set of patches are applied on caddy/ingress objects so the LMS/CMS services are used as proxies to serve SCORM resources. The backend for such proxies is the storage system used in an installation, generally MinIO, AWS S3, or an S3-compatible storage system.

When using [tutor-contrib-s3](https://github.com/hastexo/tutor-contrib-s3), we hardcode the backend URL for SCORM to `{{ S3_STORAGE_BUCKET }}.s3.amazonaws.com`. However, you can use this plugin with other S3-compatible systems, not only AWS, thus we need to provide flexibility to replace the `s3.amazonaws.com` domain with the custom storage system domain.

This PR aims to provide such flexibility and set the backend URL for SCORM to `{{ S3_STORAGE_BUCKET }}.{{ S3_HOST|default('s3.amazonaws.com', true) }}`. This will use the `S3_HOST` variable as the domain if it is non-empty. Otherwise, it will fall back to S3 default domain (`s3.amazonaws.com`)