### PR TITLE
fix: add readiness probe for lms/cms

### DIFF
--- a/drydock/patches/openedx-common-settings
+++ b/drydock/patches/openedx-common-settings
@@ -20,4 +20,4 @@ XBLOCK_SETTINGS["ScormXBlock"] = {
 {% endif %}
 
 LOGGING.get("loggers", {}).pop("tracking")
-LOGGING.get("loggers", {}).pop("local")
+LOGGING["loggers"][""]["handlers"] = ["console"]

--- a/drydock/patches/openedx-common-settings
+++ b/drydock/patches/openedx-common-settings
@@ -19,5 +19,5 @@ XBLOCK_SETTINGS["ScormXBlock"] = {
 }
 {% endif %}
 
-LOGGING.get("loggers", {}).pop("tracking")
+LOGGING["loggers"].pop("tracking")
 LOGGING["loggers"][""]["handlers"] = ["console"]

--- a/drydock/patches/openedx-common-settings
+++ b/drydock/patches/openedx-common-settings
@@ -18,3 +18,6 @@ XBLOCK_SETTINGS["ScormXBlock"] = {
     "STORAGE_FUNC": scorm_xblock_storage,
 }
 {% endif %}
+
+LOGGING.get("loggers", {}).pop("tracking")
+LOGGING.get("loggers", {}).pop("local")

--- a/drydock/patches/uwsgi-config
+++ b/drydock/patches/uwsgi-config
@@ -12,3 +12,4 @@ no-defer-accept = true
 master = true
 py-call-osafterfork = true
 vacuum = true
+hook-master-start = unix_signal:1 gracefully_kill_them_all

--- a/drydock/patches/uwsgi-config
+++ b/drydock/patches/uwsgi-config
@@ -13,3 +13,4 @@ master = true
 py-call-osafterfork = true
 vacuum = true
 hook-master-start = unix_signal:1 gracefully_kill_them_all
+disable-logging = true

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -31,6 +31,6 @@ spec:
                   value: {{ CMS_HOST }}
               path: /heartbeat
               port: 8000
-            periodSeconds: 5
+            periodSeconds: 10
             failureThreshold: 3
       terminationGracePeriodSeconds: 60

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -17,7 +17,7 @@ spec:
             httpGet:
               httpHeaders:
                 - name: Host
-                  value: {{ CMS_HOST }}
+                  value: cms
               path: /heartbeat
               port: 8000
             initialDelaySeconds: 1
@@ -28,7 +28,7 @@ spec:
             httpGet:
               httpHeaders:
                 - name: Host
-                  value: {{ CMS_HOST }}
+                  value: lms
               path: /heartbeat
               port: 8000
             initialDelaySeconds: 3

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -24,4 +24,13 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
             failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: {{ CMS_HOST }}
+              path: /heartbeat
+              port: 8000
+            periodSeconds: 5
+            failureThreshold: 3
       terminationGracePeriodSeconds: 60

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -24,19 +24,10 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
             failureThreshold: 5
-          readinessProbe:
-            httpGet:
-              httpHeaders:
-                - name: Host
-                  value: {{ CMS_HOST }}
-              path: /heartbeat
-              port: 8000
-            periodSeconds: 10
-            failureThreshold: 3
       terminationGracePeriodSeconds: 60
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
                 app.kubernetes.io/name: cms

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -18,6 +18,18 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 1
             failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: {{ LMS_HOST }}
+              path: /heartbeat
+              port: 8000
+            initialDelaySeconds: 3
+            timeoutSeconds: 30
+            periodSeconds: 60
+            failureThreshold: 2
+            successThreshold: 1
       terminationGracePeriodSeconds: 60
       affinity:
         podAntiAffinity:

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -14,7 +14,7 @@ spec:
                   value: {{ CMS_HOST }}
               path: /heartbeat
               port: 8000
-            initialDelaySeconds: 5
+            initialDelaySeconds: 1
             timeoutSeconds: 3
             periodSeconds: 1
             failureThreshold: 30
@@ -31,5 +31,5 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 0
       maxSurge: 2

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -34,3 +34,10 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
       terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cms
+            topologyKey: "kubernetes.io/hostname"

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -40,8 +40,3 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: cms
               topologyKey: kubernetes.io/hostname
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 2

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -7,12 +7,6 @@ spec:
     spec:
       containers:
         - name: cms
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - "sleep"
-                - "30"
           startupProbe:
             httpGet:
               httpHeaders:
@@ -22,13 +16,20 @@ spec:
               port: 8000
             initialDelaySeconds: 5
             timeoutSeconds: 3
-            periodSeconds: 5
-            failureThreshold: 5
+            periodSeconds: 1
+            failureThreshold: 30
       terminationGracePeriodSeconds: 60
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: cms
-            topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: cms
+              topologyKey: kubernetes.io/hostname
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 2

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -28,7 +28,7 @@ spec:
             httpGet:
               httpHeaders:
                 - name: Host
-                  value: {{ LMS_HOST }}
+                  value: {{ CMS_HOST }}
               path: /heartbeat
               port: 8000
             initialDelaySeconds: 3

--- a/drydock/templates/drydock/k8s/lifecycle/cms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/cms.yml
@@ -7,6 +7,12 @@ spec:
     spec:
       containers:
         - name: cms
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - "sleep"
+                - "15"
           startupProbe:
             httpGet:
               httpHeaders:

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -31,6 +31,6 @@ spec:
                   value: {{ CMS_HOST }}
               path: /heartbeat
               port: 8000
-            periodSeconds: 5
+            periodSeconds: 10
             failureThreshold: 3
       terminationGracePeriodSeconds: 60

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -24,19 +24,10 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
             failureThreshold: 5
-          readinessProbe:
-            httpGet:
-              httpHeaders:
-                - name: Host
-                  value: {{ LMS_HOST }}
-              path: /heartbeat
-              port: 8000
-            periodSeconds: 10
-            failureThreshold: 3
       terminationGracePeriodSeconds: 60
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
                 app.kubernetes.io/name: lms

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -24,4 +24,13 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
             failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: {{ CMS_HOST }}
+              path: /heartbeat
+              port: 8000
+            periodSeconds: 5
+            failureThreshold: 3
       terminationGracePeriodSeconds: 60

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -40,8 +40,3 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: lms
               topologyKey: kubernetes.io/hostname
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 2

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -31,5 +31,5 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 0
       maxSurge: 2

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -7,12 +7,6 @@ spec:
     spec:
       containers:
         - name: lms
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - "sleep"
-                - "30"
           startupProbe:
             httpGet:
               httpHeaders:
@@ -20,15 +14,22 @@ spec:
                   value: {{ LMS_HOST }}
               path: /heartbeat
               port: 8000
-            initialDelaySeconds: 5
+            initialDelaySeconds: 1
             timeoutSeconds: 3
-            periodSeconds: 5
-            failureThreshold: 5
+            periodSeconds: 1
+            failureThreshold: 30
       terminationGracePeriodSeconds: 60
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: lms
-            topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: lms
+              topologyKey: kubernetes.io/hostname
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 2

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -7,6 +7,12 @@ spec:
     spec:
       containers:
         - name: lms
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - "sleep"
+                - "15"
           startupProbe:
             httpGet:
               httpHeaders:

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -18,6 +18,18 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 1
             failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: {{ LMS_HOST }}
+              path: /heartbeat
+              port: 8000
+            initialDelaySeconds: 3
+            timeoutSeconds: 30
+            periodSeconds: 60
+            failureThreshold: 2
+            successThreshold: 1
       terminationGracePeriodSeconds: 60
       affinity:
         podAntiAffinity:

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -28,9 +28,16 @@ spec:
             httpGet:
               httpHeaders:
                 - name: Host
-                  value: {{ CMS_HOST }}
+                  value: {{ LMS_HOST }}
               path: /heartbeat
               port: 8000
             periodSeconds: 10
             failureThreshold: 3
       terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: lms
+            topologyKey: "kubernetes.io/hostname"

--- a/drydock/templates/drydock/k8s/lifecycle/lms.yml
+++ b/drydock/templates/drydock/k8s/lifecycle/lms.yml
@@ -7,17 +7,11 @@ spec:
     spec:
       containers:
         - name: lms
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - "sleep"
-                - "15"
           startupProbe:
             httpGet:
               httpHeaders:
                 - name: Host
-                  value: {{ LMS_HOST }}
+                  value: lms
               path: /heartbeat
               port: 8000
             initialDelaySeconds: 1
@@ -28,7 +22,7 @@ spec:
             httpGet:
               httpHeaders:
                 - name: Host
-                  value: {{ LMS_HOST }}
+                  value: lms
               path: /heartbeat
               port: 8000
             initialDelaySeconds: 3


### PR DESCRIPTION
This PR:

- Disable uwsgi request logging
- Disable `tracking.log` and `all.log` files for lms and cms pods.
- Removes the prestop hook in favor of a uwsgi hook call to gracefully terminate workers, which improved the time needed to restart or terminate lms/cms pods while being able to answer pending requests
- Adds livenessProbe for pods.
- Adds a soft pod AntiAffinity to prefer scheduling pods across nodes.
- Setups maxUnavailable to 0 to safely rollout deployments without losing capacity.
- Setups maxSurge to 2 so as not to overcommit resources temporarily for a deployment.