### PR TITLE
fix(newrelic): use the new location of uwsgi.ini in the launch command

### DIFF
--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -135,7 +135,6 @@ config = {
         "INGRESS": False,
         "INGRESS_EXTRA_HOSTS": [],
         "INGRESS_LMS_EXTRA_HOSTS": [],
-        "NEWRELIC": False,
         "NEWRELIC_LICENSE_KEY": "",
         "CUSTOM_CERTS": {},
         "DEBUG": False,

--- a/drydock/templates/drydock/k8s/newrelic.yml
+++ b/drydock/templates/drydock/k8s/newrelic.yml
@@ -2,7 +2,7 @@
   path: /spec/template/spec/containers/0/args
   value:
   - uwsgi
-  - uwsgi.ini
+  - /openedx/uwsgi.ini
 - op: add
   path: /spec/template/spec/containers/0/command
   value:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "tutor>=18.0.0,<19.0.0"
+    "tutor>=18.1.3,<19.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

The location of the uwsgi.ini file was changed in [tutor==18.1.3](https://github.com/overhangio/tutor/pull/1036) so we have to update the command run by the container. Additionally we remove an unused variable that was lingering.