### PR TITLE
fix: adding replicaset info to mongosh connection command.

### DIFF
--- a/drydock/templates/drydock/task/mongodb/init
+++ b/drydock/templates/drydock/task/mongodb/init
@@ -1,5 +1,5 @@
 echo "Initialising MongoDB..."
-mongosh --host {{MONGODB_HOST }} {% if MONGODB_ROOT_USERNAME and MONGODB_ROOT_PASSWORD %} -u {{ MONGODB_ROOT_USERNAME }} -p {{ MONGODB_ROOT_PASSWORD }} {% endif %} admin <<EOF
+mongosh --host {% if MONGODB_REPLICA_SET %}{{ MONGODB_REPLICA_SET }}/{% endif %}{{ MONGODB_HOST }} --port {{ MONGODB_PORT }} {% if MONGODB_ROOT_USERNAME and MONGODB_ROOT_PASSWORD %}-u {{ MONGODB_ROOT_USERNAME }} -p {{ MONGODB_ROOT_PASSWORD }}{% endif %} admin <<EOF
   {% if MONGODB_USERNAME %}
   if (db.getUser("{{ MONGODB_USERNAME }}") == null) {
     db.createUser({


### PR DESCRIPTION
This PR aims to:

- Include the MongoDB port in the mongosh command (useful when running MongoDB in a different port)
- Include the [replica set info in the mongosh command](https://www.mongodb.com/docs/mongodb-shell/reference/options/#std-option-mongosh.--host). It could be the case you aren't connected to a replica set primary but to a secondary one. If the replica set name is not specified, the mongosh command will fail since it is not possible to write to a secondary