### PR TITLE
fix: adjust permissions for custom named forum dbs

### DIFF
--- a/drydock/patches/openedx-common-settings
+++ b/drydock/patches/openedx-common-settings
@@ -27,3 +27,5 @@ XBLOCK_SETTINGS["ScormXBlock"] = {
 
 LOGGING["loggers"].pop("tracking")
 LOGGING["loggers"][""]["handlers"] = ["console"]
+
+FORUM_MONGODB_DATABASE = "{{ FORUM_MONGODB_DATABASE }}"

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -173,11 +173,14 @@ config = {
 }
 
 tutor_hooks.Filters.CONFIG_DEFAULTS.add_items([("OPENEDX_DEBUG_COOKIE", "ednx_enable_debug")])
-tutor_hooks.Filters.CONFIG_OVERRIDES.add_items([
+tutor_hooks.Filters.CONFIG_OVERRIDES.add_items(
+    [
         # This values are not prefixed with DRYDOCK_
+        ("FORUM_MONGODB_DATABASE", "cs_comments_service"),
         ("MONGODB_ROOT_USERNAME", ""),
         ("MONGODB_ROOT_PASSWORD", ""),
-])
+    ]
+)
 
 
 ################# You don't really have to bother about what's below this line,
@@ -197,7 +200,10 @@ tutor_hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
 # Load all patches from the "patches" folder
 for path in glob(str(importlib_resources.files("drydock") / "patches" / "*")):
     with open(path, encoding="utf-8") as patch_file:
-        tutor_hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))
+        tutor_hooks.Filters.ENV_PATCHES.add_item(
+            (os.path.basename(path), patch_file.read()),
+            tutor_hooks.priorities.LOW, # Apply our changes last to correctly override defaults.
+        )
 
 # Load all configuration entries
 tutor_hooks.Filters.CONFIG_DEFAULTS.add_items(

--- a/drydock/templates/drydock/task/mongodb/init
+++ b/drydock/templates/drydock/task/mongodb/init
@@ -7,7 +7,7 @@ mongosh --host {% if MONGODB_REPLICA_SET %}{{ MONGODB_REPLICA_SET }}/{% endif %}
         pwd:  "{{ MONGODB_PASSWORD }}",
         roles: [
           { role: "readWrite", db: "{{ MONGODB_DATABASE }}" },
-          {% if FORUM_DOCKER_IMAGE is defined %}{ role: "readWrite", db: "{{ FORUM_MONGODB_DATABASE }}" },{% endif %}
+          {% if 'forum' in PLUGINS  %}{ role: "readWrite", db: "{{ FORUM_MONGODB_DATABASE }}" },{% endif %}
         ]
     })
   } else {
@@ -15,7 +15,7 @@ mongosh --host {% if MONGODB_REPLICA_SET %}{{ MONGODB_REPLICA_SET }}/{% endif %}
       pwd: "{{ MONGODB_PASSWORD }}",
       roles: [
         { role: "readWrite", db: "{{ MONGODB_DATABASE }}" },
-        {% if FORUM_DOCKER_IMAGE is defined %}{ role: "readWrite", db: "{{ FORUM_MONGODB_DATABASE }}" },{% endif %}
+        {% if 'forum' in PLUGINS %}{ role: "readWrite", db: "{{ FORUM_MONGODB_DATABASE }}" },{% endif %}
       ]
     })
   }


### PR DESCRIPTION
# Description
The tutor-forum plugin hardcodes the value of the name of the forum
database in the Django settings, dropping the previous
`FORUM_MONGODB_DATABASE` setting (https://github.com/overhangio/tutor-forum/blob/5d3d2dd7d1ea3c9a311ac5619eb5931a111ba363/tutorforum/plugin.py#L29).

We reintroduce the `FORUM_MONGODB_DATABASE` setting and ensure the
mongodb user has permissions over the Forum Database.

In order to be able to override the hardcoded value we lower the
priority level of the Drydock patches, guaranteeing that they are going
to be applied after all the installed plugins.
