### PR TITLE
feat: create patch for registry credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following configuration options are available:
 - `DRYDOCK_ENABLE_MULTITENANCY`: Whether to enable multitennacy. Defaults to `true`.
 - `DRYDOCK_ENABLE_SCORM`: Whether to enable scorm. Defaults to `true`.
 - `DRYDOCK_POD_LIFECYCLE`: Whether to enable pod lifecycle. Defaults to `true`.
-- `DRYDOCK_REGISTRY_CREDENTIALS`: A string with the credentials to access the private registry. The format is `'{"auths":{"https://your.custom.registry/v1/":{"auth":"Abcsks45wnf"}}}'`. Defaults to `""`.
+- `DRYDOCK_REGISTRY_CREDENTIALS`: A string with the credentials to access the private registry. The format should follow the [kubernetes config.json interpretation](https://kubernetes.io/docs/concepts/containers/images/#config-json). Defaults to `""`.
 - `NGINX_STATIC_CACHE_CONFIG`: A list of dictionaries with settings for different services to cache their assets in NGINX.
   The following is an example of the expected values:
   ```yaml

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following configuration options are available:
 - `DRYDOCK_ENABLE_MULTITENANCY`: Whether to enable multitennacy. Defaults to `true`.
 - `DRYDOCK_ENABLE_SCORM`: Whether to enable scorm. Defaults to `true`.
 - `DRYDOCK_POD_LIFECYCLE`: Whether to enable pod lifecycle. Defaults to `true`.
-- `DRYDOCK_REGISTRY_CREDENTIALS`: A string with the credentials to access the private registry. The format is `'{"auths":{"https://index.docker.io/v1/":{"auth":"dXNlcjpwYXNz"}}}'`. Defaults to `""`.
+- `DRYDOCK_REGISTRY_CREDENTIALS`: A string with the credentials to access the private registry. The format is `'{"auths":{"https://your.custom.registry/v1/":{"auth":"Abcsks45wnf"}}}'`. Defaults to `""`.
 - `NGINX_STATIC_CACHE_CONFIG`: A list of dictionaries with settings for different services to cache their assets in NGINX.
   The following is an example of the expected values:
   ```yaml

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following configuration options are available:
 - `DRYDOCK_ENABLE_MULTITENANCY`: Whether to enable multitennacy. Defaults to `true`.
 - `DRYDOCK_ENABLE_SCORM`: Whether to enable scorm. Defaults to `true`.
 - `DRYDOCK_POD_LIFECYCLE`: Whether to enable pod lifecycle. Defaults to `true`.
+- `DRYDOCK_REGISTRY_CREDENTIALS`: A string with the credentials to access the private registry. The format is `'{"auths":{"https://index.docker.io/v1/":{"auth":"dXNlcjpwYXNz"}}}'`. Defaults to `""`.
 - `NGINX_STATIC_CACHE_CONFIG`: A list of dictionaries with settings for different services to cache their assets in NGINX.
   The following is an example of the expected values:
   ```yaml

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -13,6 +13,18 @@ patches:
 - target:
     kind: Deployment
   path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+- target:
+    kind: Job
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+- target:
+    kind: CronJob
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+- target:
+    kind: DaemonSet
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+- target:
+    kind: StatefulSet
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
 {% endif -%}
 - target:
     kind: Job

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -9,6 +9,11 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/lms.yml
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
+{% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+- target:
+    kind: Secret
+  path: plugins/drydock/k8s/patches/image-pull-secret.yml
+{% endif -%}
 - target:
     kind: Job
     labelSelector: app.kubernetes.io/component=job

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -19,12 +19,6 @@ patches:
 - target:
     kind: CronJob
   path: plugins/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
-- target:
-    kind: DaemonSet
-  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
-- target:
-    kind: StatefulSet
-  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
 {% endif -%}
 - target:
     kind: Job

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -9,10 +9,10 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/lms.yml
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
-{% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+{% if DRYDOCK_REGISTRY_CREDENTIALS -%}
 - target:
-    kind: Secret
-  path: plugins/drydock/k8s/patches/image-pull-secret.yml
+    kind: Deployment
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
 {% endif -%}
 - target:
     kind: Job

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -18,7 +18,7 @@ patches:
   path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
 - target:
     kind: CronJob
-  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+  path: plugins/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
 - target:
     kind: DaemonSet
   path: plugins/drydock/k8s/patches/add-image-pull-secret.yml

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -16,3 +16,6 @@
 - plugins/drydock/k8s/debug/services.yml
 - plugins/drydock/k8s/debug/ingress.yml
 {%- endif %}
+{% if DRYDOCK_REGISTRY_CREDENTIALS -%}
+- plugins/drydock/k8s/secrets/image-pull-secret.yml
+{% endif -%}

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -3,8 +3,6 @@ import functools
 import os
 import click
 import importlib_resources
-import base64
-import json
 
 import typing as t
 
@@ -72,21 +70,6 @@ def get_init_tasks():
             template["spec"]["ttlSecondsAfterFinished"] = 3600
 
             yield serialize.dumps(template)
-
-# This function transforms the image pull config into a dockerconfigjson string
-def build_dockerconfigjson(image_pull_config: list) -> str:
-    auths = {}
-    for entry in image_pull_config:
-        for registry, fields in entry.items():
-            registry_data = {}
-            for field in fields:
-                for k, v in field.items():
-                    registry_data[k] = v
-            auths[registry] = registry_data
-    dockerconfig = {"auths": auths}
-    encoded = base64.b64encode(json.dumps(dockerconfig).encode("utf-8")).decode("utf-8")
-    return encoded
-
 
 CORE_SYNC_WAVES_ORDER: SYNC_WAVES_ORDER_ATTRS_TYPE = {
     "drydock-upgrade-lms-job": 50,
@@ -177,7 +160,7 @@ config = {
             "superset-celery-beat",
         ],
         "NGINX_STATIC_CACHE_CONFIG": {},
-        "IMAGE_PULL_CONFIG": [],
+        "REGISTRY_CREDENTIALS": "",
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.
@@ -244,10 +227,6 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ('get_sync_waves_for_resource', get_sync_waves_for_resource),
     ]
 )
-
-tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items([
-    ("build_dockerconfigjson", build_dockerconfigjson),
-])
 
 # # init script
 with open(

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -3,6 +3,8 @@ import functools
 import os
 import click
 import importlib_resources
+import base64
+import json
 
 import typing as t
 
@@ -70,6 +72,20 @@ def get_init_tasks():
             template["spec"]["ttlSecondsAfterFinished"] = 3600
 
             yield serialize.dumps(template)
+
+# This function transforms the image pull config into a dockerconfigjson string
+def build_dockerconfigjson(image_pull_config: list) -> str:
+    auths = {}
+    for entry in image_pull_config:
+        for registry, fields in entry.items():
+            registry_data = {}
+            for field in fields:
+                for k, v in field.items():
+                    registry_data[k] = v
+            auths[registry] = registry_data
+    dockerconfig = {"auths": auths}
+    encoded = base64.b64encode(json.dumps(dockerconfig).encode("utf-8")).decode("utf-8")
+    return encoded
 
 
 CORE_SYNC_WAVES_ORDER: SYNC_WAVES_ORDER_ATTRS_TYPE = {
@@ -161,6 +177,7 @@ config = {
             "superset-celery-beat",
         ],
         "NGINX_STATIC_CACHE_CONFIG": {},
+        "IMAGE_PULL_CONFIG": [],
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.
@@ -227,6 +244,10 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ('get_sync_waves_for_resource', get_sync_waves_for_resource),
     ]
 )
+
+tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items([
+    ("build_dockerconfigjson", build_dockerconfigjson),
+])
 
 # # init script
 with open(

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -71,6 +71,7 @@ def get_init_tasks():
 
             yield serialize.dumps(template)
 
+
 CORE_SYNC_WAVES_ORDER: SYNC_WAVES_ORDER_ATTRS_TYPE = {
     "drydock-upgrade-lms-job": 50,
     "drydock-upgrade-cms-job": 51,

--- a/drydock/templates/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
+++ b/drydock/templates/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: not-used
+metadata:
+  name: not-used
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          imagePullSecrets:
+            - name: image-pull-secret

--- a/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+        - name: image-pull-secret

--- a/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: not-used
 metadata:
   name: not-used
 spec:

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret-{{ K8S_NAMESPACE }}
+  namespace: {{ K8S_NAMESPACE }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: "{{ DRYDOCK_IMAGE_PULL_CONFIG | b64encode }}"

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: image-pull-secret-{{ K8S_NAMESPACE }}
-  namespace: {{ K8S_NAMESPACE }}
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: "{{ build_dockerconfigjson(config('DRYDOCK_IMAGE_PULL_CONFIG')) }}"

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: "{{ DRYDOCK_IMAGE_PULL_CONFIG | b64encode }}"
+  .dockerconfigjson: "{{ build_dockerconfigjson(config('DRYDOCK_IMAGE_PULL_CONFIG')) }}"

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret
+  namespace: {{ K8S_NAMESPACE }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {{ DRYDOCK_REGISTRY_CREDENTIALS }}


### PR DESCRIPTION
# Description:
This PR creates the new Secret for include additionals registry credentials

## Configuration:
In `config.yaml` you must add the configuration like this:

```yaml
DRYDOCK_REGISTRY_CREDENTIALS: '{"auths":{"https://index.docker.io/v1/":{"auth":"dXNlcjpwYXNz"}}}'
```