### PR TITLE
feat: redwood create patch for registry credentials

### DIFF
--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -10,7 +10,6 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
 {% if DRYDOCK_IMAGE_PULL_CONFIG -%}
-- path: plugins/drydock/k8s/secrets/image-pull-secret.yml
 - target:
     kind: Deployment
   path: plugins/drydock/k8s/patches/add-image-pull-secret.yml

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -9,6 +9,11 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/lms.yml
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
+{% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+- target:
+    kind: Secret
+  path: plugins/drydock/k8s/patches/image-pull-secret.yml
+{% endif -%}
 - target:
     kind: Job
     labelSelector: app.kubernetes.io/component=job

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -9,7 +9,7 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/lms.yml
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
-{% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+{% if DRYDOCK_REGISTRY_CREDENTIALS -%}
 - target:
     kind: Deployment
   path: plugins/drydock/k8s/patches/add-image-pull-secret.yml

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -10,9 +10,10 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
 {% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+- path: plugins/drydock/k8s/secrets/image-pull-secret.yml
 - target:
-    kind: Secret
-  path: plugins/drydock/k8s/patches/image-pull-secret.yml
+    kind: Deployment
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
 {% endif -%}
 - target:
     kind: Job

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -16,6 +16,6 @@
 - plugins/drydock/k8s/debug/services.yml
 - plugins/drydock/k8s/debug/ingress.yml
 {%- endif %}
-{% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+{% if DRYDOCK_REGISTRY_CREDENTIALS -%}
 - plugins/drydock/k8s/secrets/image-pull-secret.yml
 {% endif -%}

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -16,3 +16,6 @@
 - plugins/drydock/k8s/debug/services.yml
 - plugins/drydock/k8s/debug/ingress.yml
 {%- endif %}
+{% if DRYDOCK_IMAGE_PULL_CONFIG -%}
+- plugins/drydock/k8s/secrets/image-pull-secret.yml
+{% endif -%}

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -238,8 +238,14 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
     ]
 )
 
+def get_dockerconfigjson_b64():
+    context = click.get_current_context().obj
+    tutor_conf = tutor_config.load(context.root)
+    image_pull_config = tutor_conf.get("DRYDOCK_IMAGE_PULL_CONFIG", [])
+    return build_dockerconfigjson(image_pull_config)
+
 tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items([
-    ("build_dockerconfigjson", build_dockerconfigjson),
+    ("drydock_image_pull_secret_b64", get_dockerconfigjson_b64),
 ])
 
 # # init script

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -73,15 +73,6 @@ def get_init_tasks():
 
             yield serialize.dumps(template)
 
-# This function transforms the image pull config into a dockerconfigjson string
-def build_dockerconfigjson(image_pull_config: list) -> str:
-    auths = {}
-    for entry in image_pull_config:
-        for registry, fields in entry.items():
-            auths[registry] = fields
-    dockerconfig = {"auths": auths}
-    return base64.b64encode(json.dumps(dockerconfig).encode("utf-8")).decode("utf-8")
-
 CORE_SYNC_WAVES_ORDER: SYNC_WAVES_ORDER_ATTRS_TYPE = {
     "drydock-upgrade-lms-job": 50,
     "drydock-upgrade-cms-job": 51,
@@ -171,7 +162,7 @@ config = {
             "superset-celery-beat",
         ],
         "NGINX_STATIC_CACHE_CONFIG": {},
-        "IMAGE_PULL_CONFIG": [],
+        "REGISTRY_CREDENTIALS": "",
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.
@@ -232,16 +223,6 @@ tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items(
         ('get_sync_waves_for_resource', get_sync_waves_for_resource),
     ]
 )
-
-def get_dockerconfigjson_b64():
-    context = click.get_current_context().obj
-    tutor_conf = tutor_config.load(context.root)
-    image_pull_config = tutor_conf.get("DRYDOCK_IMAGE_PULL_CONFIG", [])
-    return build_dockerconfigjson(image_pull_config)
-
-tutor_hooks.Filters.ENV_TEMPLATE_VARIABLES.add_items([
-    ("drydock_image_pull_secret_b64", get_dockerconfigjson_b64),
-])
 
 # # init script
 with open(

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -78,14 +78,9 @@ def build_dockerconfigjson(image_pull_config: list) -> str:
     auths = {}
     for entry in image_pull_config:
         for registry, fields in entry.items():
-            registry_data = {}
-            for field in fields:
-                for k, v in field.items():
-                    registry_data[k] = v
-            auths[registry] = registry_data
+            auths[registry] = fields
     dockerconfig = {"auths": auths}
-    encoded = base64.b64encode(json.dumps(dockerconfig).encode("utf-8")).decode("utf-8")
-    return encoded
+    return base64.b64encode(json.dumps(dockerconfig).encode("utf-8")).decode("utf-8")
 
 CORE_SYNC_WAVES_ORDER: SYNC_WAVES_ORDER_ATTRS_TYPE = {
     "drydock-upgrade-lms-job": 50,

--- a/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+        - name: image-pull-secret

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret-{{ K8S_NAMESPACE }}
+  namespace: {{ K8S_NAMESPACE }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: "{{ build_dockerconfigjson(config('DRYDOCK_IMAGE_PULL_CONFIG')) }}"

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: image-pull-secret-{{ K8S_NAMESPACE }}
+  name: images-pull-secret
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 data:

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: images-pull-secret
-  namespace: {{ K8S_NAMESPACE }}
+  name: not-used
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: "{{ drydock_image_pull_secret_b64() }}"

--- a/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/image-pull-secret.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: "{{ build_dockerconfigjson(config('DRYDOCK_IMAGE_PULL_CONFIG')) }}"
+  .dockerconfigjson: "{{ drydock_image_pull_secret_b64() }}"

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -4,5 +4,5 @@ metadata:
   name: image-pull-secret
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
-data:
+stringData:
   .dockerconfigjson: "{{ DRYDOCK_REGISTRY_CREDENTIALS }}"

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: "{{ DRYDOCK_REGISTRY_CREDENTIALS }}"
+  .dockerconfigjson: '{{ DRYDOCK_REGISTRY_CREDENTIALS }}'

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -5,4 +5,5 @@ metadata:
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: {{ DRYDOCK_REGISTRY_CREDENTIALS }}
+  .dockerconfigjson: |
+    {{ DRYDOCK_REGISTRY_CREDENTIALS }}

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: "{{ drydock_image_pull_secret_b64() }}"
+  .dockerconfigjson: "{{ DRYDOCK_REGISTRY_CREDENTIALS }}"

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: not-used
+  name: image-pull-secret
+  namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: "{{ drydock_image_pull_secret_b64() }}"

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ K8S_NAMESPACE }}
 type: kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: '{{ DRYDOCK_REGISTRY_CREDENTIALS }}'
+  .dockerconfigjson: {{ DRYDOCK_REGISTRY_CREDENTIALS }}


### PR DESCRIPTION
# Description:
This PR creates the new Secret for include additionals registry credentials

## Configuration:
In `config.yaml` you must add the configuration like this:

```yaml
DRYDOCK_IMAGE_PULL_CONFIG:
- ghcr.io:
    auth: dXNlcjpwYXNz
    password: pass1
    username: usuario1
- registry.gitlab.com:
    password: pass2
    username: usuario2
- your.private.registry.example.com:
    password: pass3
    username: usuario3
```

The JSON equivalent is:

```JSON
{
   "auths":{
      "ghcr.io":{
         "auth":"dXNlcjpwYXNz",
         "password":"pass1",
         "username":"usuario1"
      },
      "registry.gitlab.com":{
         "password":"pass2",
         "username":"usuario2"
      },
      "your.private.registry.example.com":{
         "password":"pass3",
         "username":"usuario3"
      }
} 
```