### PR TITLE
feat: create patch for registry credentials (#154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following configuration options are available:
 - `DRYDOCK_ENABLE_SENTRY`: Whether to enable sentry. Defaults to `true`.
 - `DRYDOCK_SENTRY_DSN`: The sentry DSN. Defaults to `""`.
 - `DRYDOCK_POD_LIFECYCLE`: Whether to enable pod lifecycle. Defaults to `true`.
+- `DRYDOCK_REGISTRY_CREDENTIALS`: A string with the credentials to access the private registry. The format should follow the [kubernetes config.json interpretation](https://kubernetes.io/docs/concepts/containers/images/#config-json). Defaults to `""`.
 - `NGINX_STATIC_CACHE_CONFIG`: A list of dictionaries with settings for different services to cache their assets in NGINX.
   The following is an example of the expected values:
   ```yaml

--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -9,6 +9,17 @@ patches:
 - path: plugins/drydock/k8s/lifecycle/lms.yml
 - path: plugins/drydock/k8s/lifecycle/cms.yml
 {% endif -%}
+{% if DRYDOCK_REGISTRY_CREDENTIALS -%}
+- target:
+    kind: Deployment
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+- target:
+    kind: Job
+  path: plugins/drydock/k8s/patches/add-image-pull-secret.yml
+- target:
+    kind: CronJob
+  path: plugins/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
+{% endif -%}
 - target:
     kind: Job
     labelSelector: app.kubernetes.io/component=job

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -19,3 +19,6 @@
 - plugins/drydock/k8s/debug/services.yml
 - plugins/drydock/k8s/debug/ingress.yml
 {%- endif %}
+{% if DRYDOCK_REGISTRY_CREDENTIALS -%}
+- plugins/drydock/k8s/secrets/image-pull-secret.yml
+{% endif -%}

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -166,6 +166,7 @@ config = {
             "superset-celery-beat",
         ],
         "NGINX_STATIC_CACHE_CONFIG": {},
+        "REGISTRY_CREDENTIALS": "",
     },
     # Add here settings that don't have a reasonable default for all users. For
     # instance: passwords, secret keys, etc.

--- a/drydock/templates/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
+++ b/drydock/templates/drydock/k8s/patches/add-image-pull-secret-cronjob.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: not-used
+metadata:
+  name: not-used
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          imagePullSecrets:
+            - name: image-pull-secret

--- a/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/patches/add-image-pull-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: not-used
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      imagePullSecrets:
+        - name: image-pull-secret

--- a/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
+++ b/drydock/templates/drydock/k8s/secrets/image-pull-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret
+  namespace: {{ K8S_NAMESPACE }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {{ DRYDOCK_REGISTRY_CREDENTIALS }}


### PR DESCRIPTION
# Description:
This PR creates the new Secret for include additionals registry credentials

## Configuration:
In `config.yaml` you must add the configuration like this:

```yaml
DRYDOCK_REGISTRY_CREDENTIALS: '{"auths":{"https://index.docker.io/v1/":{"auth":"dXNlcjpwYXNz"}}}'
```