### PR TITLE
fix: add meilisearch and notes ingress

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,5 +1,6 @@
 tutor~=19.0
 tutor-mfe~=19.0
+tutor-forum~=19.0
 tutor-minio~=19.0
 setuptools
 git+https://github.com/edunext/tutor-contrib-s3@sumac

--- a/drydock/patches/kustomization-resources
+++ b/drydock/patches/kustomization-resources
@@ -8,6 +8,8 @@
 - plugins/drydock/k8s/ingress/lms.yml
 - plugins/drydock/k8s/ingress/cms.yml
 - plugins/drydock/k8s/ingress/mfe.yml
+- plugins/drydock/k8s/ingress/meilisearch.yml
+- plugins/drydock/k8s/ingress/notes.yml
 - plugins/drydock/k8s/ingress/extra-hosts.yml
 - plugins/drydock/k8s/ingress/static-cache.yml
 {%- endif %}

--- a/drydock/templates/drydock/k8s/ingress/meilisearch.yml
+++ b/drydock/templates/drydock/k8s/ingress/meilisearch.yml
@@ -1,0 +1,34 @@
+{%- if RUN_MEILISEARCH %}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: meilisearch
+  namespace: {{ K8S_NAMESPACE }}
+  {%- if DRYDOCK_AUTO_TLS and not DRYDOCK_CUSTOM_CERTS %}
+  annotations:
+    cert-manager.io/issuer: letsencrypt
+  {%- endif %}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ MEILISEARCH_HOST }}
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {% if DRYDOCK_BYPASS_CADDY -%}meilisearch{% else -%}caddy{% endif %}
+            port:
+              number: {% if DRYDOCK_BYPASS_CADDY -%}7700{% else -%}80{% endif %}
+  {%- if DRYDOCK_AUTO_TLS or DRYDOCK_CUSTOM_CERTS %}
+  tls:
+  - hosts:
+    - {{ MEILISEARCH_HOST }}
+    {%- if DRYDOCK_CUSTOM_CERTS %}
+    secretName: {{ DRYDOCK_CUSTOM_CERTS["secret_name"]|default("custom-tls-certs") }}
+    {%- else %}
+    secretName: meilisearch-host-tls
+    {%- endif %}
+  {%- endif %}
+{%- endif %}

--- a/drydock/templates/drydock/k8s/ingress/notes.yml
+++ b/drydock/templates/drydock/k8s/ingress/notes.yml
@@ -1,0 +1,34 @@
+{%- if 'notes' in PLUGINS %}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: notes
+  namespace: {{ K8S_NAMESPACE }}
+  {%- if DRYDOCK_AUTO_TLS and not DRYDOCK_CUSTOM_CERTS %}
+  annotations:
+    cert-manager.io/issuer: letsencrypt
+  {%- endif %}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ NOTES_HOST }}
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {% if DRYDOCK_BYPASS_CADDY -%}notes{% else -%}caddy{% endif %}
+            port:
+              number: {% if DRYDOCK_BYPASS_CADDY -%}7700{% else -%}80{% endif %}
+  {%- if DRYDOCK_AUTO_TLS or DRYDOCK_CUSTOM_CERTS %}
+  tls:
+  - hosts:
+    - {{ NOTES_HOST }}
+    {%- if DRYDOCK_CUSTOM_CERTS %}
+    secretName: {{ DRYDOCK_CUSTOM_CERTS["secret_name"]|default("custom-tls-certs") }}
+    {%- else %}
+    secretName: notes-host-tls
+    {%- endif %}
+  {%- endif %}
+{%- endif %}


### PR DESCRIPTION
Both services expose a public API and should come with an ingress by default. Previously you would have use the `DRYDOCK_INGRESS_EXTRA_HOSTS` setting in order to create the additional ingress objects.

This changes are mostly cherry-picked from #163, and should also be included in the sumac release