### PR TITLE
feat: add support for TLS connections to clickhouse

### DIFF
--- a/drydock/patches/kustomization
+++ b/drydock/patches/kustomization
@@ -31,3 +31,13 @@ patches:
     kind: Deployment
     name: '{% for name in DRYDOCK_POST_INIT_DEPLOYMENTS %}{{ name }}{% if not loop.last %}|{% endif %}{% endfor %}'
   path: plugins/drydock/k8s/patches/post-init-deployments-sync-wave.yml
+
+- path: plugins/drydock/k8s/patches/tls-volume-append.yml
+  target: 
+    kind: "(Deployment|Job)"
+    name: aspects|superset-job.*|aspects-job.*|ralph
+
+- path: plugins/drydock/k8s/patches/tls-volume-add.yml
+  target:
+    kind: "(Deployment|Job)"
+    name: clickhouse-job.*

--- a/drydock/plugin.py
+++ b/drydock/plugin.py
@@ -152,6 +152,7 @@ config = {
         "PDB_MINAVAILABLE_PERCENTAGE_MFE": 0,
         "PDB_MINAVAILABLE_PERCENTAGE_FORUM": 0,
         "PDB_MINAVAILABLE_PERCENTAGE_CADDY": 0,
+        "CA_BUNDLE_NAME": "cluster-bundle",
         "POST_INIT_DEPLOYMENTS": [
             "lms",
             "cms",

--- a/drydock/templates/drydock/k8s/patches/tls-volume-add.yml
+++ b/drydock/templates/drydock/k8s/patches/tls-volume-add.yml
@@ -1,0 +1,17 @@
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+    - name: ca-certificates
+      configMap:
+        name: cluster-bundle
+        defaultMode: 420 # Octal 0644
+        optional: false
+        items:
+          - key: ca-certificates.crt
+            path: ca-certificates.crt
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts
+  value:
+   -  name: ca-certificates
+      readOnly: true
+      mountPath: /etc/ssl/certs

--- a/drydock/templates/drydock/k8s/patches/tls-volume-append.yml
+++ b/drydock/templates/drydock/k8s/patches/tls-volume-append.yml
@@ -1,0 +1,17 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: ca-certificates
+    configMap:
+      name: cluster-bundle
+      defaultMode: 420 # Octal 0644
+      optional: false
+      items:
+        - key: ca-certificates.crt
+          path: ca-certificates.crt
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: ca-certificates
+    readOnly: true
+    mountPath: /etc/ssl/certs


### PR DESCRIPTION
This adds a few patches that mount a CA certificate to the trust store of selected pods.

